### PR TITLE
fix(ci): validate passport template from spec submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       
       - name: Validate passport schema
         run: |
-          # Validate against OAP v1.0 schema
-          jq . templates/passport.template.json > /dev/null
+          # Validate OAP v1 template from spec submodule is valid JSON
+          jq . external/aport-spec/oap/examples/passport.template.v1.json > /dev/null
           echo "✅ Passport template is valid JSON"
       
       - name: Test guardrail script


### PR DESCRIPTION
Fixes CI failure: validate `external/aport-spec/oap/examples/passport.template.v1.json` instead of missing `templates/passport.template.json`.

Merge this into staging, then merge **staging → main** (PR #2) to release.

