### PR TITLE
fix: always install plugin, restart gateway, smoke test; CI passport tests

### DIFF
--- a/.cursor/rules/no-cursor-pr-footer.mdc
+++ b/.cursor/rules/no-cursor-pr-footer.mdc
@@ -1,0 +1,10 @@
+---
+description: Do not add Cursor branding to pull requests
+globs:
+alwaysApply: true
+---
+
+# PR and commit content
+
+- **Never** append or include "Made with [Cursor](https://cursor.com)" (or any Cursor branding) in pull request titles, descriptions, or commit messages.
+- When creating or suggesting PR text (e.g. via `gh pr create`), do not add a Cursor footer or attribution.

--- a/README.md
+++ b/README.md
@@ -318,22 +318,6 @@ See [Verification methods](docs/VERIFICATION_METHODS.md) for a detailed comparis
 
 ---
 
-## 🦐 Porter — APort Mascot
-
-<div align="center">
-
-![Porter — APort mascot](docs/assets/porter.svg)
-
-</div>
-
-[**Porter**](https://aport.io/brand-mascot-agent/) is the official passport guard for AI agents: trustworthy, fast, and friendly. Use Porter in your docs or dashboards; SVGs and an interactive playground are on the [brand page](https://aport.io/brand-mascot-agent/).
-
-<!-- Add a demo GIF here when you have one, e.g.:
-![Porter verifying a command](docs/assets/porter-demo.gif)
--->
-
----
-
 ## 📜 Scripts Reference
 
 | Script | Purpose |
@@ -439,4 +423,4 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ---
 
-<p align="center">Made with ❤️ by the APort team</p>
+<p align="center">Made with ❤️ by [Uchi](https://github.com/uchibeke/)</p>

--- a/bin/openclaw
+++ b/bin/openclaw
@@ -86,11 +86,9 @@ echo "    ⚠️  AI follows prompts to call guardrail"
 echo "    ⚠️  Can be bypassed via prompt injection"
 echo "    ⚠️  Not deterministic"
 echo ""
-read -p "  Install APort OpenClaw plugin? [Y/n]: " install_plugin
-install_plugin=${install_plugin:-y}
 
 PLUGIN_INSTALLED=false
-if [ "$install_plugin" = "y" ] || [ "$install_plugin" = "Y" ]; then
+if true; then
     # Check if openclaw CLI is available
     if ! command -v openclaw &> /dev/null; then
         echo ""
@@ -124,31 +122,25 @@ if [ "$install_plugin" = "y" ] || [ "$install_plugin" = "Y" ]; then
                 echo "  ⚠️  Plugin installed but not showing in 'openclaw plugins list'"
             fi
             echo ""
-            read -p "  Start or restart OpenClaw gateway now to load the plugin? [Y/n]: " do_restart
-            do_restart="${do_restart:-y}"
-            if [ "$do_restart" != "n" ] && [ "$do_restart" != "N" ]; then
-                export OPENCLAW_CONFIG_DIR="$CONFIG_DIR"
-                # Restart only works when gateway is already running; else start in background.
-                # Never let gateway start/restart fail the APort installation.
-                if openclaw gateway restart 2>/dev/null; then
-                    echo "  ✅ Gateway restarted; plugin is active."
-                else
-                    # Gateway was not running; start it in background so setup completes without blocking.
-                    # Any failure here must not break APort installation (no exit 1).
-                    mkdir -p "$CONFIG_DIR/logs" 2>/dev/null || true
-                    ( OPENCLAW_CONFIG_DIR="$CONFIG_DIR" nohup openclaw gateway start >> "$CONFIG_DIR/logs/gateway.log" 2>&1 & ) 2>/dev/null || true
-                    sleep 2
-                    if openclaw gateway probe 2>/dev/null; then
-                        echo "  ✅ Gateway started in background; plugin is active."
-                        echo "     Dashboard: http://127.0.0.1:18789/"
-                    else
-                        echo "  ⚠️  Gateway start was initiated; it may still be starting."
-                        echo "     If the dashboard is unreachable, run: openclaw doctor"
-                        echo "     Then start in a terminal: openclaw gateway start"
-                    fi
-                fi
+            export OPENCLAW_CONFIG_DIR="$CONFIG_DIR"
+            # Restart only works when gateway is already running; else start in background.
+            # Never let gateway start/restart fail the APort installation.
+            if openclaw gateway restart 2>/dev/null; then
+                echo "  ✅ Gateway restarted; plugin is active."
             else
-                echo "  To load the plugin, start or restart the gateway: openclaw gateway start"
+                # Gateway was not running; start it in background so setup completes without blocking.
+                # Any failure here must not break APort installation (no exit 1).
+                mkdir -p "$CONFIG_DIR/logs" 2>/dev/null || true
+                ( OPENCLAW_CONFIG_DIR="$CONFIG_DIR" nohup openclaw gateway start >> "$CONFIG_DIR/logs/gateway.log" 2>&1 & ) 2>/dev/null || true
+                sleep 2
+                if openclaw gateway probe 2>/dev/null; then
+                    echo "  ✅ Gateway started in background; plugin is active."
+                    echo "     Dashboard: http://127.0.0.1:18789/"
+                else
+                    echo "  ⚠️  Gateway start was initiated; it may still be starting."
+                    echo "     If the dashboard is unreachable, run: openclaw doctor"
+                    echo "     Then start in a terminal: openclaw gateway start"
+                fi
             fi
         fi
     fi
@@ -511,17 +503,12 @@ fi
 echo ""
 echo "  View status: $CONFIG_DIR/.skills/aport-status.sh"
 echo ""
-read -p "  Run the smoke test now? [Y/n]: " run_test
-run_test=${run_test:-y}
-if [ "$run_test" = "y" ] || [ "$run_test" = "Y" ]; then
-    echo ""
-    echo "  Running: $CONFIG_DIR/.skills/aport-guardrail.sh system.command.execute '{\"command\":\"node --version\"}'"
-    if "$CONFIG_DIR/.skills/aport-guardrail.sh" system.command.execute '{"command":"node --version"}'; then
-        echo "  ✅ Test passed (exit 0 = ALLOW)"
-    else
-        echo "  ❌ Test denied or failed (exit 1). Check passport/limits or run: $CONFIG_DIR/.skills/aport-status.sh"
-    fi
-    echo ""
+echo "  Running smoke test: $CONFIG_DIR/.skills/aport-guardrail.sh system.command.execute '{\"command\":\"node --version\"}'"
+if "$CONFIG_DIR/.skills/aport-guardrail.sh" system.command.execute '{"command":"node --version"}'; then
+    echo "  ✅ Smoke test passed (exit 0 = ALLOW)"
+else
+    echo "  ❌ Smoke test denied or failed (exit 1). Check passport/limits or run: $CONFIG_DIR/.skills/aport-status.sh"
 fi
+echo ""
 echo "  Done. OpenClaw config: $CONFIG_DIR"
 echo ""

--- a/docs/OPENCLAW_LOCAL_INTEGRATION.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION.md
@@ -600,4 +600,4 @@ OpenClaw is now secure with APort policy enforcement. All commands and MCP tools
 
 ---
 
-**Made with ❤️ by the APort team**
+**Made with ❤️ by Uchi (https://github.com/uchibeke/)**

--- a/tests/test-full-flow.sh
+++ b/tests/test-full-flow.sh
@@ -12,9 +12,13 @@ FLOW_PASSPORT="$TEST_DIR/fullflow_passport.json"
 rm -f "$FLOW_PASSPORT" "$OPENCLAW_PASSPORT_FILE"
 
 echo "  Full flow: create passport..."
-# Prompt order includes exec_allow_scope when exec_cap=y (empty = default list)
-printf '%s\n' '' '' '' '' 'y' 'y' 'n' 'n' '500' '10' '*' '' 'n' | \
-    "$CREATE_SCRIPT" --output "$FLOW_PASSPORT" >/dev/null 2>&1 || true
+# In CI (non-TTY) use --non-interactive for reliable creation; otherwise use piped defaults
+if [ ! -t 0 ]; then
+    "$CREATE_SCRIPT" --output "$FLOW_PASSPORT" --non-interactive
+else
+    printf '%s\n' '' '' '' '' 'y' 'y' 'n' 'n' '500' '10' '*' '' 'n' | \
+        "$CREATE_SCRIPT" --output "$FLOW_PASSPORT" >/dev/null 2>&1 || true
+fi
 
 if [ ! -f "$FLOW_PASSPORT" ]; then
     echo "FAIL: passport was not created" >&2

--- a/tests/test-passport-creation.sh
+++ b/tests/test-passport-creation.sh
@@ -10,14 +10,13 @@ CREATED_PASSPORT="$TEST_DIR/passport_created.json"
 rm -f "$OPENCLAW_PASSPORT_FILE"
 
 echo "  Passport creation: run wizard with piped input..."
-# Prompt order: owner_id, owner_type, agent_name, agent_description,
-#   pr_cap, exec_cap, msg_cap, data_cap,
-#   max_pr_size, max_prs_per_day, allowed_repos,
-#   exec_allow_scope (default or *),
-#   should_expire (n = never)
-# Empty line = use default; y/n for capabilities; n = never expire
-printf '%s\n' '' '' '' '' 'y' 'y' 'n' 'n' '500' '10' '*' '' 'n' | \
-    "$CREATE_SCRIPT" --output "$CREATED_PASSPORT" >/dev/null 2>&1 || true
+# In CI (non-TTY) use --non-interactive for reliable creation; otherwise use piped defaults
+if [ ! -t 0 ]; then
+    "$CREATE_SCRIPT" --output "$CREATED_PASSPORT" --non-interactive
+else
+    printf '%s\n' '' '' '' '' 'y' 'y' 'n' 'n' '500' '10' '*' '' 'n' | \
+        "$CREATE_SCRIPT" --output "$CREATED_PASSPORT" >/dev/null 2>&1 || true
+fi
 
 if [ ! -f "$CREATED_PASSPORT" ]; then
     echo "FAIL: passport file was not created at $CREATED_PASSPORT" >&2


### PR DESCRIPTION
## Summary
- **Starter script (bin/openclaw):** Always install APort OpenClaw plugin, restart/start gateway, and run smoke test (no prompts).
- **CI:** Passport creation tests use `--non-interactive` when stdin is not a TTY so they pass in CI.
- **Project:** Cursor rule to never append Cursor branding to PRs; README/docs tweaks.

