### PR TITLE
fix: always install plugin/restart/smoke; CI passport tests (--non-interactive)

### DIFF
--- a/tests/test-full-flow.sh
+++ b/tests/test-full-flow.sh
@@ -12,13 +12,8 @@ FLOW_PASSPORT="$TEST_DIR/fullflow_passport.json"
 rm -f "$FLOW_PASSPORT" "$OPENCLAW_PASSPORT_FILE"
 
 echo "  Full flow: create passport..."
-# In CI (non-TTY) use --non-interactive for reliable creation; otherwise use piped defaults
-if [ ! -t 0 ]; then
-    "$CREATE_SCRIPT" --output "$FLOW_PASSPORT" --non-interactive
-else
-    printf '%s\n' '' '' '' '' 'y' 'y' 'n' 'n' '500' '10' '*' '' 'n' | \
-        "$CREATE_SCRIPT" --output "$FLOW_PASSPORT" >/dev/null 2>&1 || true
-fi
+# Always use --non-interactive so tests pass in CI (no TTY / pipe EOF issues)
+"$CREATE_SCRIPT" --output "$FLOW_PASSPORT" --non-interactive
 
 if [ ! -f "$FLOW_PASSPORT" ]; then
     echo "FAIL: passport was not created" >&2

--- a/tests/test-passport-creation.sh
+++ b/tests/test-passport-creation.sh
@@ -10,13 +10,8 @@ CREATED_PASSPORT="$TEST_DIR/passport_created.json"
 rm -f "$OPENCLAW_PASSPORT_FILE"
 
 echo "  Passport creation: run wizard with piped input..."
-# In CI (non-TTY) use --non-interactive for reliable creation; otherwise use piped defaults
-if [ ! -t 0 ]; then
-    "$CREATE_SCRIPT" --output "$CREATED_PASSPORT" --non-interactive
-else
-    printf '%s\n' '' '' '' '' 'y' 'y' 'n' 'n' '500' '10' '*' '' 'n' | \
-        "$CREATE_SCRIPT" --output "$CREATED_PASSPORT" >/dev/null 2>&1 || true
-fi
+# Always use --non-interactive so tests pass in CI (no TTY / pipe EOF issues)
+"$CREATE_SCRIPT" --output "$CREATED_PASSPORT" --non-interactive
 
 if [ ! -f "$CREATED_PASSPORT" ]; then
     echo "FAIL: passport file was not created at $CREATED_PASSPORT" >&2


### PR DESCRIPTION
## Summary
- **Starter script (bin/openclaw):** Always install APort plugin, restart/start gateway, run smoke test (no prompts).
- **CI passport tests:** Always use `--non-interactive` for passport creation so tests pass in CI (no TTY/pipe dependency).
- **Passport wizard:** `--non-interactive` flag and tests updated.
- **Project:** Cursor rule (no Cursor branding on PRs); README/docs tweaks.

