### PR TITLE
chore: tag-driven release, @aporthq scope, npx UX, and release docs

### DIFF
--- a/.cursor/rules/release-process.mdc
+++ b/.cursor/rules/release-process.mdc
@@ -1,0 +1,15 @@
+---
+description: Release process for this repo — tag-driven, same steps every time
+globs: ["package.json", "CHANGELOG.md", "RELEASE.md", "PUBLISHING.md", ".github/workflows/release.yml"]
+alwaysApply: false
+---
+
+# Release process (aport-agent-guardrails)
+
+- **Releases are not automatic on merge to main.** A release happens only when a **tag** `v*` is pushed.
+- **Process (repeat every release):**
+  1. Bump `version` in **package.json** and update **CHANGELOG.md** (version section + date). Merge to `main`.
+  2. From local `main`: `git pull origin main`, then `git tag vX.Y.Z` (tag must match `package.json` version), then `git push origin vX.Y.Z`.
+  3. CI runs: [Release workflow](.github/workflows/release.yml) publishes to npm and creates the GitHub Release.
+- **Do not** create the release in the GitHub UI — the workflow creates it from the tag. Do not prompt the user to "create a release" manually; direct them to tag and push.
+- Reference: [RELEASE.md](RELEASE.md) and [PUBLISHING.md](PUBLISHING.md) at repo root.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,21 @@
+# Release: publish to npm and create GitHub Release.
+# Trigger: push a tag v* (e.g. v1.0.1). Merges to main do NOT release.
 name: Release
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
-  publish-npm:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:
@@ -19,3 +26,11 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" --generate-notes
+        if: success()

--- a/.npmignore
+++ b/.npmignore
@@ -25,5 +25,4 @@ node_modules/
 # Local overrides
 local-overrides/
 
-# External (submodules - users should git clone, not npm install)
-external/
+# External/ is included in package "files" when publishing (submodules bundled at release)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,64 @@
+# Publishing Guide
+
+How we publish **APort Agent Guardrails** to npm and what gets shipped.
+
+## What gets published
+
+Each **GitHub Release** (e.g. `v1.0.0`) triggers the [Release workflow](.github/workflows/release.yml), which runs `npm publish` from the repo root.
+
+**Published package:** [`@aporthq/agent-guardrails`](https://www.npmjs.com/package/@aporthq/agent-guardrails)
+
+**Contents of the npm tarball:**
+
+| Path | Description |
+|------|-------------|
+| `bin/` | All scripts: `openclaw` (setup wizard), `aport-guardrail.sh`, `aport-create-passport.sh`, etc. |
+| `src/` | Node evaluator and server |
+| `extensions/openclaw-aport/` | OpenClaw plugin (deterministic enforcement) |
+| `external/` | Policy packs and spec (aport-policies, aport-spec) — bundled at publish time from submodules |
+| `docs/` | QUICKSTART, TOOL_POLICY_MAPPING, etc. |
+| `templates/`, `policies/`, `LICENSE`, `README.md` | Supporting files |
+
+So after `npm install @aporthq/agent-guardrails` or `npx @aporthq/agent-guardrails`, the package is **self-contained**: no git clone or submodule init required.
+
+## User-facing entrypoints
+
+- **`npx @aporthq/agent-guardrails`** — runs the setup wizard (`bin/openclaw`): passport, plugin install, gateway restart, smoke test. This is the recommended one-command flow.
+- **`aport-guardrail`** (from installed package) — run a single guardrail check (e.g. from CI or after setup).
+
+## Release workflow (tag-driven)
+
+**Merges to main are not releases.** A release happens only when you push a **tag** `v*`.
+
+1. **Bump version** in `package.json` and in `CHANGELOG.md` (in a PR, then merge to `main`).
+2. **Tag and push** (from your local `main`, or from the merge commit):
+   ```bash
+   git checkout main && git pull
+   git tag v1.0.1   # must match package.json "version"
+   git push origin v1.0.1
+   ```
+3. **CI runs automatically:** the [Release workflow](.github/workflows/release.yml) triggers on tag push. It:
+   - Checks out that tag with submodules
+   - Runs `npm publish`
+   - Creates the GitHub Release for that tag (with generated notes)
+
+So: **same process every time** — bump version, merge to main, then `git tag vX.Y.Z && git push origin vX.Y.Z`. No need to create the release in the GitHub UI. See [RELEASE.md](RELEASE.md) for the exact checklist.
+
+## Comparison to agent-passport
+
+| Aspect | agent-passport | aport-agent-guardrails |
+|--------|----------------|------------------------|
+| Structure | Monorepo (SDK node/python, middleware) | Single npm package + bundled submodules |
+| Publish trigger | Tags / manual “Publish Packages” | Tag push `v*` (then npm publish + release created) |
+| Version bump | `npm run version:patch` etc. | Manual in package.json + CHANGELOG |
+| What’s published | Multiple packages (npm + PyPI) | One package: `@aporthq/agent-guardrails` |
+
+## Prerequisites
+
+- **GitHub:** Push a tag `vX.Y.Z`; workflow runs and creates the release.
+- **npm:** `NPM_TOKEN` (Automation token) in repo secrets so the workflow can publish.
+
+## Troubleshooting
+
+- **Publish fails:** Ensure `NPM_TOKEN` is set and the version in `package.json` is **newer** than the last published version.
+- **Package missing policies/spec:** Ensure the Release workflow uses `actions/checkout` with `submodules: recursive` so `external/` is included in the tarball.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p>
   <a href="https://aport.io">Website</a> •
-  <a href="https://docs.aport.io">Docs</a> •
+  <a href="https://aport.io/docs">Docs</a> •
   <a href="https://aport.io/brand-mascot-agent/">Meet Porter</a> •
   <a href="#-quick-start">Quick Start</a>
 </p>
@@ -57,9 +57,17 @@ Your AI agent should **only do what you explicitly allow**. APort Agent Guardrai
 
 ## 🚀 Quick Start
 
-**Prerequisites:** Node 18+, `jq` (for bash guardrail).
+**Prerequisites:** Node 18+, `jq` (for bash guardrail). OpenClaw CLI in PATH for plugin install (optional; wizard will prompt).
 
-**One command** — clone, init submodules, and run the installer (copy and paste the block):
+**One command (recommended)** — run the setup wizard via npx (no clone required):
+
+```bash
+npx @aporthq/agent-guardrails
+```
+
+This downloads the package (includes policies and plugin), runs the setup wizard, installs the APort OpenClaw plugin, restarts the gateway, and runs a smoke test.
+
+**Alternative: clone the repo** (e.g. to hack on it or use without npm):
 
 ```bash
 git clone https://github.com/aporthq/aport-agent-guardrails.git && \
@@ -67,11 +75,6 @@ git clone https://github.com/aporthq/aport-agent-guardrails.git && \
   git submodule update --init --recursive && \
   ./bin/openclaw
 ```
-
-- **`git clone ...`** — clone the repo  
-- **`cd aport-agent-guardrails`** — enter the repo  
-- **`git submodule update --init --recursive`** — fetch policy packs (aport-policies, aport-spec)  
-- **`./bin/openclaw`** — run the setup wizard (passport, plugin, config, self-check)
 
 *Already have the repo?* From the repo root run: `git submodule update --init --recursive && ./bin/openclaw`
 
@@ -121,7 +124,8 @@ Shows:
 - ⚙️ Configured limits
 - 📊 Recent activity log
 
-📖 **Full guide:** [QuickStart: OpenClaw Plugin](docs/QUICKSTART_OPENCLAW_PLUGIN.md)
+📖 **Full guide:** [QuickStart: OpenClaw Plugin](docs/QUICKSTART_OPENCLAW_PLUGIN.md)  
+📦 **Publishing:** [PUBLISHING.md](PUBLISHING.md) — what’s in the npm package and how we release.
 
 ---
 
@@ -146,6 +150,8 @@ Shows:
 |------|----------|-----------|---------|
 | **API (default)** | Production, full policy parity, new policy packs without code changes | ✅ | Yes (api.aport.io or self-hosted) |
 | **Local (bash)** | Privacy, offline, air-gapped | Subset only (hand-coded limits for exec, messaging, repo) | No |
+
+**API mode** can use either a **local passport file** (sent in the request body; not stored) or **agent_id only**: set `APORT_AGENT_ID` to your hosted passport’s agent ID and the API fetches the passport from the registry — no passport JSON file needed. See [tests/test-remote-passport-api.sh](tests/test-remote-passport-api.sh).
 
 Deep dive (what each supports, comparison table): [Verification methods](docs/VERIFICATION_METHODS.md).
 
@@ -418,7 +424,7 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ## 🔗 Links
 
-- [APort](https://aport.io) · [Docs](https://docs.aport.io) · [Meet Porter](https://aport.io/brand-mascot-agent/)
+- [APort](https://aport.io) · [Docs](https://aport.io/docs)
 - [GitHub Issues](https://github.com/aporthq/aport-agent-guardrails/issues) · [Discussions](https://github.com/aporthq/aport-agent-guardrails/discussions)
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+# How to release
+
+Same process every time. **Merges to main are not releases** — only pushing a tag triggers a release.
+
+## Steps
+
+1. **Bump version** (in a PR, then merge to `main`):
+   - `package.json`: set `"version": "X.Y.Z"` (e.g. `1.0.1`).
+   - `CHANGELOG.md`: add/update the section for that version and release date.
+
+2. **Tag and push** (after the version bump is on `main`):
+   ```bash
+   git checkout main && git pull origin main
+   git tag v1.0.1   # must match package.json "version"
+   git push origin v1.0.1
+   ```
+
+3. **CI does the rest:** The Release workflow runs on tag push. It publishes to npm and creates the GitHub Release (with generated notes).
+
+## After v1.0.0
+
+For the next release (e.g. v1.0.1): bump to `1.0.1` in `package.json` and CHANGELOG, merge to main, then:
+
+```bash
+git pull origin main
+git tag v1.0.1
+git push origin v1.0.1
+```
+
+See [PUBLISHING.md](PUBLISHING.md) for what gets published and prerequisites (`NPM_TOKEN`).

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aport/openclaw-aport",
+  "name": "@aporthq/openclaw-aport",
   "version": "1.0.0",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@aport/agent-guardrails",
+  "name": "@aporthq/agent-guardrails",
   "version": "1.0.0",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "bin": {
-    "aport": "./bin/aport-guardrail.sh"
+    "aport": "./bin/openclaw",
+    "aport-guardrail": "./bin/aport-guardrail.sh"
   },
   "scripts": {
     "test": "make test",
@@ -34,6 +35,8 @@
   "files": [
     "bin/",
     "src/",
+    "extensions/",
+    "external/",
     "templates/",
     "policies/",
     "docs/",

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,6 +48,7 @@ cd extensions/openclaw-aport && node test.js
 | **`test-kill-switch.sh`** | Kill switch: absent → allow, present → deny (`oap.kill_switch_active`), removed → allow. |
 | **`test-passport-missing-and-invalid.sh`** | Missing passport → `oap.passport_not_found`, invalid JSON → `oap.passport_invalid`, suspended → `oap.passport_suspended`. |
 | **`test-api-evaluator.sh`** | API-powered evaluator (default: local agent-passport); skip if API unreachable. |
+| **`test-remote-passport-api.sh`** | **Remote passport (API mode):** Uses `APORT_AGENT_ID` only (no passport file). API fetches passport from registry. Set `APORT_TEST_REMOTE_AGENT_ID` to test a specific hosted passport; skip with `APORT_SKIP_REMOTE_PASSPORT_TEST=1`. |
 | **`test-plugin-guardrail-cli.sh`** | **Plugin-style CLI:** Same tool names and context as the OpenClaw plugin — `system.command.execute` (mkdir, ls) ALLOW; `messaging.message.send` ALLOW with `messaging.send` passport, DENY without. |
 
 **Plugin tests** (`extensions/openclaw-aport/test.js`):


### PR DESCRIPTION
## Summary
- **Release:** Workflow triggers on tag push `v*` (not on merge to main). Publish to npm and create GitHub Release from tag. See RELEASE.md.
- **Scope:** `@aporthq/agent-guardrails` and `@aporthq/openclaw-aport`; README and PUBLISHING use `@aporthq`.
- **npx:** Default bin is `openclaw` (setup wizard). Package includes `extensions/` and `external/` for self-contained `npx @aporthq/agent-guardrails`.
- **Docs:** PUBLISHING.md, RELEASE.md, .cursor/rules/release-process.mdc for repeatable release process.
- **.npmignore:** Allow `external/` in published package.

Merge to staging, then merge staging → main when ready.

