### PR TITLE
fix(release): publish as public and fix package.json for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version: "22"
 
-      - name: Publish to npm
-        run: npm publish
+      - name: Fix package.json for npm
+        run: npm pkg fix
+
+      - name: Publish to npm (public)
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aporthq/aport-agent-guardrails.git"
+    "url": "git+https://github.com/aporthq/aport-agent-guardrails.git"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Summary
- Release workflow: `npm publish --access public` so @aporthq/agent-guardrails is public (fixes 402)
- Add `npm pkg fix` step before publish
- package.json: normalize repository.url to git+https

Merge to staging, then staging → main. After merge to main, tag and push to re-run release.

Made with [Cursor](https://cursor.com)