### PR TITLE
fix(release): npm publish as public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version: "22"
 
-      - name: Publish to npm
-        run: npm publish
+      - name: Fix package.json for npm
+        run: npm pkg fix
+
+      - name: Publish to npm (public)
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aporthq/aport-agent-guardrails.git"
+    "url": "git+https://github.com/aporthq/aport-agent-guardrails.git"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Summary
Merging staging into main: release workflow now uses `npm publish --access public` and `npm pkg fix`; repository.url normalized.

## After merge
Re-tag to trigger release: delete old tag if needed, then `git checkout main && git pull && git tag v1.0.1 && git push origin v1.0.1` (or tag v1.0.2 if 1.0.1 was already published).
