### PR TITLE
Merge staging: npm package tests, docs lead with npx, conditional install

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -21,6 +21,8 @@ Each **GitHub Release** (e.g. `v1.0.0`) triggers the [Release workflow](.github/
 
 So after `npm install @aporthq/agent-guardrails` or `npx @aporthq/agent-guardrails`, the package is **self-contained**: no git clone or submodule init required.
 
+**Does the guardrail get installed without `make install`?** Yes. The **setup wizard** (`bin/openclaw`, run when you execute `npx @aporthq/agent-guardrails`) does the installation: it creates wrappers in your config dir (e.g. `~/.openclaw/.skills/`) that point back at the package’s `bin/` and `external/`. So the interactive setup does not use Make at all. The package’s `install` script runs `make install` only when a Makefile is present (i.e. when installed from a clone, to copy scripts into `~/.openclaw/.skills`); when installed from the npm tarball there is no Makefile, so the script no-ops and install succeeds.
+
 ## User-facing entrypoints
 
 - **`npx @aporthq/agent-guardrails`** — runs the setup wizard (`bin/openclaw`): passport, plugin install, gateway restart, smoke test. This is the recommended one-command flow.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # 🛡️ APort Agent Guardrails
 
+[![npm](https://img.shields.io/npm/v/@aporthq/agent-guardrails.svg)](https://www.npmjs.com/package/@aporthq/agent-guardrails)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.0-green.svg)](package.json)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen.svg)](tests/)
 [![Node](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)](package.json)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-%3E%3D2026.2.0-blue.svg)](extensions/openclaw-aport/package.json)
@@ -11,6 +11,7 @@
 **Pre-action authorization for AI agents.** Verify permissions *before* every tool runs — works with [OpenClaw](https://github.com/openclaw/openclaw), [IronClaw](https://github.com/nearai/ironclaw), PicoClaw, and compatible frameworks.
 
 <p>
+  <a href="https://www.npmjs.com/package/@aporthq/agent-guardrails">npm</a> •
   <a href="https://aport.io">Website</a> •
   <a href="https://aport.io/docs">Docs</a> •
   <a href="https://aport.io/brand-mascot-agent/">Meet Porter</a> •
@@ -59,7 +60,7 @@ Your AI agent should **only do what you explicitly allow**. APort Agent Guardrai
 
 **Prerequisites:** Node 18+, `jq` (for bash guardrail). OpenClaw CLI in PATH for plugin install (optional; wizard will prompt).
 
-**One command (recommended)** — run the setup wizard via npx (no clone required):
+**One command (recommended)** — run the setup wizard via the [npm package](https://www.npmjs.com/package/@aporthq/agent-guardrails) (no clone required):
 
 ```bash
 npx @aporthq/agent-guardrails
@@ -424,7 +425,7 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ## 🔗 Links
 
-- [APort](https://aport.io) · [Docs](https://aport.io/docs)
+- [npm package](https://www.npmjs.com/package/@aporthq/agent-guardrails) · [APort](https://aport.io) · [Docs](https://aport.io/docs)
 - [GitHub Issues](https://github.com/aporthq/aport-agent-guardrails/issues) · [Discussions](https://github.com/aporthq/aport-agent-guardrails/discussions)
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -3,9 +3,15 @@
 
 ---
 
-## Recommended: interactive OpenClaw setup (one command)
+## Recommended: one command (npm, no clone)
 
-From the repo root:
+```bash
+npx @aporthq/agent-guardrails
+```
+
+This uses the [npm package](https://www.npmjs.com/package/@aporthq/agent-guardrails): downloads the package, runs the setup wizard, installs the plugin and wrappers, and runs a smoke test.
+
+**Alternative: from the repo** (if you cloned the repo):
 
 ```bash
 make openclaw-setup

--- a/docs/QUICKSTART_OPENCLAW_PLUGIN.md
+++ b/docs/QUICKSTART_OPENCLAW_PLUGIN.md
@@ -2,7 +2,17 @@
 
 **5-minute setup for deterministic, platform-level policy enforcement in OpenClaw.**
 
-**One command to get started** (clone + submodules + installer):
+**One command to get started** (recommended — no clone):
+
+```bash
+npx @aporthq/agent-guardrails
+```
+
+This uses the [npm package](https://www.npmjs.com/package/@aporthq/agent-guardrails): it downloads the package (policies + plugin), runs the setup wizard, installs the APort OpenClaw plugin, and runs a smoke test.
+
+Then start OpenClaw with the generated config (e.g. `openclaw gateway start --config ~/.openclaw/config.yaml`). The plugin will enforce policies on every tool call.
+
+**Alternative: clone the repo** (e.g. to hack on the code or use without npm):
 
 ```bash
 git clone https://github.com/aporthq/aport-agent-guardrails.git && \
@@ -10,8 +20,6 @@ git clone https://github.com/aporthq/aport-agent-guardrails.git && \
   git submodule update --init --recursive && \
   ./bin/openclaw
 ```
-
-Then start OpenClaw with the generated config (e.g. `openclaw gateway start --config ~/.openclaw/config.yaml`). The plugin will enforce policies on every tool call.
 
 *Already have the repo?* From the repo root run: `./bin/openclaw`
 
@@ -30,7 +38,7 @@ Then start OpenClaw with the generated config (e.g. `openclaw gateway start --co
 
 ## Installation (Automatic)
 
-**Recommended:** Use the one-liner above, or from the repo root run:
+**Recommended:** Use `npx @aporthq/agent-guardrails` (see top of this doc). If you cloned the repo instead, from the repo root run:
 
 ```bash
 ./bin/openclaw

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "make test",
-    "install": "make install",
+    "install": "([ -f Makefile ] && make install) || true",
     "server": "node src/server/index.js",
     "dev": "node --watch src/server/index.js",
     "sync-submodules": "git submodule update --init --recursive",

--- a/tests/README.md
+++ b/tests/README.md
@@ -50,6 +50,7 @@ cd extensions/openclaw-aport && node test.js
 | **`test-api-evaluator.sh`** | API-powered evaluator (default: local agent-passport); skip if API unreachable. |
 | **`test-remote-passport-api.sh`** | **Remote passport (API mode):** Uses `APORT_AGENT_ID` only (no passport file). API fetches passport from registry. Set `APORT_TEST_REMOTE_AGENT_ID` to test a specific hosted passport; skip with `APORT_SKIP_REMOTE_PASSPORT_TEST=1`. |
 | **`test-plugin-guardrail-cli.sh`** | **Plugin-style CLI:** Same tool names and context as the OpenClaw plugin — `system.command.execute` (mkdir, ls) ALLOW; `messaging.message.send` ALLOW with `messaging.send` passport, DENY without. |
+| **`test-npm-package.sh`** | **Published npm package:** In a temp dir, `npm install @aporthq/agent-guardrails` (with `--ignore-scripts` for current publish), asserts package layout (`bin/`, `external/`), runs guardrail for ALLOW and DENY. Requires network. |
 
 **Plugin tests** (`extensions/openclaw-aport/test.js`):
 

--- a/tests/test-npm-package.sh
+++ b/tests/test-npm-package.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Test the published npm package @aporthq/agent-guardrails: install and run guardrail.
+# Run from repo root: bash tests/test-npm-package.sh
+# Requires: npm, jq. Uses a temp dir; does not pollute repo.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE_PASSPORT="$REPO_ROOT/tests/fixtures/passport.oap-v1.json"
+TEST_DIR="${APORT_TEST_DIR:-$(mktemp -d 2>/dev/null || echo "$REPO_ROOT/tests/output")}"
+mkdir -p "$TEST_DIR"
+cd "$TEST_DIR"
+
+echo "  NPM package: install @aporthq/agent-guardrails in $TEST_DIR"
+npm init -y >/dev/null 2>&1
+# --ignore-scripts: avoid make install (for clone-from-repo); published package has conditional install
+npm install "@aporthq/agent-guardrails" --no-save --no-package-lock --ignore-scripts >/dev/null 2>&1
+
+PKG_ROOT="$TEST_DIR/node_modules/@aporthq/agent-guardrails"
+if [ ! -d "$PKG_ROOT" ]; then
+    echo "FAIL: package not found at $PKG_ROOT" >&2
+    exit 1
+fi
+if [ ! -f "$PKG_ROOT/bin/aport-guardrail.sh" ]; then
+    echo "FAIL: bin/aport-guardrail.sh missing in package" >&2
+    exit 1
+fi
+if [ ! -d "$PKG_ROOT/external" ]; then
+    echo "FAIL: external/ missing in package (policies/spec)" >&2
+    exit 1
+fi
+echo "  NPM package: layout OK (bin/, external/)"
+
+export OPENCLAW_PASSPORT_FILE="$TEST_DIR/passport.json"
+export OPENCLAW_DECISION_FILE="$TEST_DIR/decision.json"
+cp "$FIXTURE_PASSPORT" "$OPENCLAW_PASSPORT_FILE"
+
+GUARDRAIL="$PKG_ROOT/bin/aport-guardrail.sh"
+chmod +x "$GUARDRAIL" 2>/dev/null || true
+
+echo "  NPM package: guardrail ALLOW (safe command)..."
+if ! "$GUARDRAIL" system.command.execute '{"command":"ls"}'; then
+    echo "FAIL: expected ALLOW for ls" >&2
+    exit 1
+fi
+echo "  NPM package: guardrail DENY (blocked pattern)..."
+if "$GUARDRAIL" system.command.execute '{"command":"rm -rf /"}'; then
+    echo "FAIL: expected DENY for rm -rf /" >&2
+    exit 1
+fi
+
+echo "  NPM package: setup wizard script present..."
+[ -f "$PKG_ROOT/bin/openclaw" ] || { echo "FAIL: bin/openclaw missing"; exit 1; }
+
+echo "  NPM package tests passed."
+exit 0

--- a/tests/test-remote-passport-api.sh
+++ b/tests/test-remote-passport-api.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Test remote (hosted) passport with API mode: use agent_id only, no passport file.
+# The API fetches the passport from the registry by agent_id.
+#
+# Usage: ./test-remote-passport-api.sh
+#   Optional: APORT_TEST_REMOTE_AGENT_ID=ap_xxx  (default: ap_8955f5450cd542fe8f67bbbf07c3e103)
+#   Optional: APORT_API_URL=http://localhost:8787 (default; or https://api.aport.io for cloud)
+#   Optional: APORT_API_KEY=... (if API requires auth)
+#
+# Skip: set APORT_SKIP_REMOTE_PASSPORT_TEST=1 to skip (e.g. in CI without a real passport).
+#
+# Verification flow (same as other API tests):
+#   1. Test calls bin/aport-guardrail-api.sh with tool name (e.g. system.command.execute) and context JSON.
+#   2. Script maps tool → policy pack ID (system.command.execute → system.command.execute.v1), then runs src/evaluator.js.
+#   3. Evaluator (with APORT_AGENT_ID set) POSTs to:
+#        ${APORT_API_URL}/api/verify/policy/system.command.execute.v1
+#      with body: { "context": { "agent_id": "<APORT_AGENT_ID>", "command": "ls" } }.
+#   4. API fetches passport from registry by agent_id, evaluates policy, returns allow/deny.
+
+set -e
+
+source "$(dirname "$0")/setup.sh"
+
+# Remote passport (hosted) to test — create one at https://aport.io/builder/create
+REMOTE_AGENT_ID="${APORT_TEST_REMOTE_AGENT_ID:-ap_8955f5450cd542fe8f67bbbf07c3e103}"
+
+if [ -n "$APORT_SKIP_REMOTE_PASSPORT_TEST" ]; then
+    echo "  Skipping remote passport API test (APORT_SKIP_REMOTE_PASSPORT_TEST is set)"
+    exit 0
+fi
+
+# Use API mode with agent_id only (no local passport file)
+export APORT_AGENT_ID="$REMOTE_AGENT_ID"
+export APORT_API_URL="${APORT_API_URL:-http://localhost:8787}"
+# Point passport file to non-existent so we truly use agent_id path; script allows this when APORT_AGENT_ID is set
+export OPENCLAW_PASSPORT_FILE="$TEST_DIR/nonexistent-passport-remote.json"
+export OPENCLAW_DECISION_FILE="$TEST_DIR/decision-remote.json"
+rm -f "$OPENCLAW_PASSPORT_FILE" "$OPENCLAW_DECISION_FILE"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GUARDRAIL_API="$SCRIPT_DIR/bin/aport-guardrail-api.sh"
+
+echo ""
+echo "  Remote passport API test (agent_id only, no passport file)"
+echo "  Agent ID: $REMOTE_AGENT_ID"
+echo "  API: $APORT_API_URL"
+echo ""
+
+# Probe API reachability (agent-passport exposes GET /api/status, not /health)
+if ! curl -sf --connect-timeout 5 "${APORT_API_URL%/}/api/status" >/dev/null 2>&1; then
+    echo "  Skipping: API unreachable at $APORT_API_URL (set APORT_SKIP_REMOTE_PASSPORT_TEST=1 to suppress)"
+    exit 0
+fi
+
+echo "  Test 1: ALLOW — safe command (e.g. ls)"
+if "$GUARDRAIL_API" system.command.execute '{"command":"ls"}'; then
+    echo "  ✅ Test 1 passed: Command allowed"
+else
+    echo "  ❌ Test 1 failed: Expected ALLOW for command 'ls'"
+    [ -f "$OPENCLAW_DECISION_FILE" ] && jq -r '.reasons[0].message // .' "$OPENCLAW_DECISION_FILE"
+    exit 1
+fi
+
+echo ""
+echo "  Test 2: DENY — blocked pattern (rm -rf)"
+if ! "$GUARDRAIL_API" system.command.execute '{"command":"rm -rf /"}'; then
+    echo "  ✅ Test 2 passed: Blocked pattern denied"
+else
+    echo "  ❌ Test 2 failed: Expected DENY for 'rm -rf /'"
+    [ -f "$OPENCLAW_DECISION_FILE" ] && jq -r '.reasons[0].message // .' "$OPENCLAW_DECISION_FILE"
+    exit 1
+fi
+
+rm -f "$OPENCLAW_DECISION_FILE"
+echo ""
+echo "  ✅ All remote passport API tests passed!"


### PR DESCRIPTION
## Summary
Staging includes: npm package tests (`test-npm-package.sh`, `test-remote-passport-api.sh`), docs leading with npx and clone as alternative, conditional `package.json` install script for npm tarball, and PUBLISHING.md/tests README updates.

All tests pass.

Made with [Cursor](https://cursor.com)