### PR TITLE
Release v1.0.5: APort data in aport/, path resolver, SKILL from repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-02-17
+
+### Added
+- **APort data directory:** Passport, decision, audit, and kill-switch files now live under `config_dir/aport/` (e.g. `~/.openclaw/aport/passport.json`) for a cleaner layout. New installs use this path; existing installs continue to work (backward compatible).
+- **Path resolver:** `bin/aport-resolve-paths.sh` — single source of truth for resolving APort paths; `aport-guardrail-bash.sh`, `aport-guardrail-api.sh`, and `aport-status.sh` source it (DRY, consistent behavior).
+- **SKILL from repo:** Installer copies `skills/aport-guardrail/SKILL.md` into the config dir instead of a hardcoded heredoc, so the installed skill always matches the repo.
+
+### Changed
+- **Default paths:** Plugin and create-passport default to `~/.openclaw/aport/passport.json`; wrappers default to `config_dir/aport/` for all four files.
+- **SKILL.md:** Removed shield emoji/references; clarified that users do not run the guardrail script manually (plugin enforces automatically); added `agent_id` option and OpenClaw docs links; document passport at `~/.openclaw/aport/passport.json` and repo clone for `./bin/openclaw`.
+- **Docs:** QUICKSTART_OPENCLAW_PLUGIN, extension README, and related docs updated for aport/ paths and legacy fallback.
+
+### Fixed
+- **API guardrail:** `aport-guardrail-api.sh` now sources the path resolver so it finds the passport at the legacy location when the wrapper points to `aport/` and the file exists only in the config root.
+
 ## [1.0.4] - 2026-02-16
 
 ### Fixed
@@ -116,6 +131,10 @@ None (first release).
 
 ---
 
-[Unreleased]: https://github.com/aporthq/aport-agent-guardrails/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/aporthq/aport-agent-guardrails/compare/v1.0.5...HEAD
+[1.0.5]: https://github.com/aporthq/aport-agent-guardrails/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/aporthq/aport-agent-guardrails/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/aporthq/aport-agent-guardrails/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/aporthq/aport-agent-guardrails/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/aporthq/aport-agent-guardrails/releases/tag/v1.0.1
 [1.0.0]: https://github.com/aporthq/aport-agent-guardrails/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -434,4 +434,4 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ---
 
-<p align="center">Made with ❤️ by [Uchi](https://github.com/uchibeke/)</p>
+<p align="center">Made with ❤️ by [Uchi](https://github.com/uchibeke/) </p>

--- a/bin/aport-create-passport.sh
+++ b/bin/aport-create-passport.sh
@@ -4,7 +4,7 @@
 # Use for any framework; for OpenClaw with a custom config directory, run ./bin/openclaw instead.
 #
 # Usage: ./aport-create-passport.sh [--output FILE] [--non-interactive]
-#   --output FILE       Write passport to FILE (e.g. /path/to/my-openclaw/passport.json)
+#   --output FILE       Write passport to FILE (e.g. /path/to/my-openclaw/aport/passport.json)
 #   --non-interactive   Use defaults only; no prompts (for CI/tests).
 #
 # When OPENCLAW_CONFIG_DIR is set (e.g. by bin/openclaw), the wizard reads defaults
@@ -13,7 +13,7 @@
 
 set -e
 
-PASSPORT_FILE="$HOME/.openclaw/passport.json"
+PASSPORT_FILE="$HOME/.openclaw/aport/passport.json"
 NON_INTERACTIVE=""
 # Parse --output and --non-interactive
 while [ $# -gt 0 ]; do

--- a/bin/aport-guardrail-api.sh
+++ b/bin/aport-guardrail-api.sh
@@ -10,13 +10,11 @@
 
 set -e
 
-PASSPORT_FILE="${OPENCLAW_PASSPORT_FILE:-$HOME/.openclaw/passport.json}"
-DECISION_FILE="${OPENCLAW_DECISION_FILE:-$HOME/.openclaw/decision.json}"
-AUDIT_LOG="${OPENCLAW_AUDIT_LOG:-$HOME/.openclaw/audit.log}"
-KILL_SWITCH="${OPENCLAW_KILL_SWITCH:-$HOME/.openclaw/kill-switch}"
-
-# Get script directory to find Node.js evaluator
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolve paths: config_dir/aport/ (new) or config_dir (legacy); same as bash guardrail
+# shellcheck source=bin/aport-resolve-paths.sh
+. "${SCRIPT_DIR}/bin/aport-resolve-paths.sh"
+
 NODE_EVALUATOR="$SCRIPT_DIR/src/evaluator.js"
 
 TOOL_NAME="$1"
@@ -29,7 +27,7 @@ if [ -n "$DEBUG_APORT" ]; then
     echo "DEBUG: CONTEXT_JSON=$CONTEXT_JSON" >&2
 fi
 
-# Ensure audit log directory exists
+# Ensure APort data dir exists (for decision, audit)
 mkdir -p "$(dirname "$AUDIT_LOG")"
 
 # Check if Node.js is available

--- a/bin/aport-guardrail-bash.sh
+++ b/bin/aport-guardrail-bash.sh
@@ -5,13 +5,12 @@
 
 set -e
 
-PASSPORT_FILE="${OPENCLAW_PASSPORT_FILE:-$HOME/.openclaw/passport.json}"
-DECISION_FILE="${OPENCLAW_DECISION_FILE:-$HOME/.openclaw/decision.json}"
-AUDIT_LOG="${OPENCLAW_AUDIT_LOG:-$HOME/.openclaw/audit.log}"
-KILL_SWITCH="${OPENCLAW_KILL_SWITCH:-$HOME/.openclaw/kill-switch}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolve paths: config_dir/aport/ (new) or config_dir (legacy)
+# shellcheck source=bin/aport-resolve-paths.sh
+. "${SCRIPT_DIR}/bin/aport-resolve-paths.sh"
 
 # Get script directory to find submodules (external/ per GIT_SUBMODULES_EXPLAINED.md)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 POLICIES_DIR="$SCRIPT_DIR/external/aport-policies"
 LOCAL_POLICIES_DIR="$SCRIPT_DIR/local-overrides/policies"
 
@@ -27,7 +26,7 @@ if [ -n "$DEBUG_APORT" ]; then
     echo "DEBUG: CONTEXT length=${#CONTEXT_JSON}" >&2
 fi
 
-# Ensure audit log directory exists
+# Ensure APort data dir exists (for decision.json, audit.log)
 mkdir -p "$(dirname "$AUDIT_LOG")"
 
 # Function to load policy from upstream or local-overrides

--- a/bin/aport-resolve-paths.sh
+++ b/bin/aport-resolve-paths.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Resolve APort data paths: prefer config_dir/aport/, fallback to config_dir (legacy).
+# MUST be sourced by any script that reads/writes passport, decision, audit, or kill-switch:
+#   - aport-guardrail-bash.sh
+#   - aport-guardrail-api.sh
+#   - aport-status.sh
+# (aport-create-passport.sh uses --output; wrappers set env so children get resolved paths.)
+# Sets: OPENCLAW_PASSPORT_FILE, OPENCLAW_DECISION_FILE, OPENCLAW_AUDIT_LOG, OPENCLAW_KILL_SWITCH
+# and PASSPORT_FILE, DECISION_FILE, AUDIT_LOG, KILL_SWITCH for script use.
+# Caller must ensure APORT_DATA_DIR exists before writing (e.g. mkdir -p "$(dirname "$AUDIT_LOG")").
+
+resolve_aport_paths() {
+    local config_dir
+    local passport_path
+    local data_dir
+
+    # 1) Explicit path set and file exists → use it (plugin or wrapper)
+    if [ -n "${OPENCLAW_PASSPORT_FILE:-}" ] && [ -f "$OPENCLAW_PASSPORT_FILE" ]; then
+        data_dir="$(dirname "$OPENCLAW_PASSPORT_FILE")"
+        passport_path="$OPENCLAW_PASSPORT_FILE"
+    # 2) Explicit path set but file missing → legacy: try parent dir (e.g. .../openclaw/passport.json)
+    elif [ -n "${OPENCLAW_PASSPORT_FILE:-}" ]; then
+        config_dir="$(cd "$(dirname "$OPENCLAW_PASSPORT_FILE")/.." 2>/dev/null && pwd)"
+        if [ -f "${config_dir}/passport.json" ]; then
+            passport_path="${config_dir}/passport.json"
+            data_dir="$config_dir"
+        else
+            passport_path="$OPENCLAW_PASSPORT_FILE"
+            data_dir="$(dirname "$OPENCLAW_PASSPORT_FILE")"
+        fi
+    # 3) No env → try aport then legacy
+    else
+        config_dir="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
+        config_dir="${config_dir/#\~/$HOME}"
+        if [ -f "${config_dir}/aport/passport.json" ]; then
+            passport_path="${config_dir}/aport/passport.json"
+            data_dir="${config_dir}/aport"
+        elif [ -f "${config_dir}/passport.json" ]; then
+            passport_path="${config_dir}/passport.json"
+            data_dir="$config_dir"
+        else
+            passport_path="${config_dir}/aport/passport.json"
+            data_dir="${config_dir}/aport"
+        fi
+    fi
+
+    export OPENCLAW_PASSPORT_FILE="$passport_path"
+    export OPENCLAW_DECISION_FILE="${data_dir}/decision.json"
+    export OPENCLAW_AUDIT_LOG="${data_dir}/audit.log"
+    export OPENCLAW_KILL_SWITCH="${data_dir}/kill-switch"
+
+    PASSPORT_FILE="$OPENCLAW_PASSPORT_FILE"
+    DECISION_FILE="$OPENCLAW_DECISION_FILE"
+    AUDIT_LOG="$OPENCLAW_AUDIT_LOG"
+    KILL_SWITCH="$OPENCLAW_KILL_SWITCH"
+}
+
+# When sourced, resolve immediately so callers just use the vars
+resolve_aport_paths

--- a/bin/aport-status.sh
+++ b/bin/aport-status.sh
@@ -6,10 +6,9 @@
 
 set -e
 
-PASSPORT_FILE="${OPENCLAW_PASSPORT_FILE:-$HOME/.openclaw/passport.json}"
-AUDIT_LOG="${OPENCLAW_AUDIT_LOG:-$HOME/.openclaw/audit.log}"
-KILL_SWITCH="${OPENCLAW_KILL_SWITCH:-$HOME/.openclaw/kill-switch}"
-DECISION_FILE="${OPENCLAW_DECISION_FILE:-$HOME/.openclaw/decision.json}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/aport-resolve-paths.sh
+. "${SCRIPT_DIR}/bin/aport-resolve-paths.sh"
 
 if [ "$1" = "--passport" ] && [ -n "$2" ]; then
     PASSPORT_FILE="$2"

--- a/bin/openclaw
+++ b/bin/openclaw
@@ -83,12 +83,23 @@ fi
 mkdir -p "$CONFIG_DIR"
 CONFIG_DIR="$(cd "$CONFIG_DIR" && pwd)"
 
+# APort data: passport, decision, audit, kill-switch in config_dir/aport/
+APORT_DIR="$CONFIG_DIR/aport"
+mkdir -p "$APORT_DIR"
+
 echo ""
 echo "  ✓ Using: $CONFIG_DIR"
 echo ""
 
 # 2. Passport setup (hosted or local)
-PASSPORT_FILE="$CONFIG_DIR/passport.json"
+# Resolve passport path: prefer aport/, fallback to config root (legacy)
+if [ -f "$APORT_DIR/passport.json" ]; then
+    PASSPORT_FILE="$APORT_DIR/passport.json"
+elif [ -f "$CONFIG_DIR/passport.json" ]; then
+    PASSPORT_FILE="$CONFIG_DIR/passport.json"
+else
+    PASSPORT_FILE="$APORT_DIR/passport.json"
+fi
 export OPENCLAW_CONFIG_DIR="$CONFIG_DIR"
 USE_HOSTED_PASSPORT=false
 
@@ -273,8 +284,8 @@ YAML
         else
             cat >> "$CONFIG_YAML" << YAML
 
-        # Passport file location
-        passportFile: $CONFIG_DIR/passport.json
+        # Passport file location (in aport/ subdir)
+        passportFile: $PASSPORT_FILE
 
         # For local mode: path to guardrail script
         guardrailScript: $CONFIG_DIR/.skills/aport-guardrail-bash.sh
@@ -318,7 +329,7 @@ YAML
             if [ "$USE_HOSTED_PASSPORT" = true ]; then
                 echo "        agentId: $HOSTED_AGENT_ID" >> "$CONFIG_YAML"
             else
-                echo "        passportFile: $CONFIG_DIR/passport.json" >> "$CONFIG_YAML"
+                echo "        passportFile: $PASSPORT_FILE" >> "$CONFIG_YAML"
                 echo "        guardrailScript: $CONFIG_DIR/.skills/aport-guardrail-bash.sh" >> "$CONFIG_YAML"
             fi
 
@@ -346,10 +357,10 @@ YAML
                 --arg allow_unmapped "$ALLOW_UNMAPPED" \
                 '{ mode: $mode, agentId: $agent_id, failClosed: true, allowUnmappedTools: ($allow_unmapped == "true") } + (if $mode == "api" then { apiUrl: $api_url } else {} end)')
         else
-            # Local passport config (passportFile)
+            # Local passport config (passportFile in aport/)
             CONFIG_JSON=$(jq -n \
                 --arg mode "$PLUGIN_MODE" \
-                --arg pf "$CONFIG_DIR/passport.json" \
+                --arg pf "$PASSPORT_FILE" \
                 --arg gs "$CONFIG_DIR/.skills/aport-guardrail-bash.sh" \
                 --arg api_url "$api_url_val" \
                 --arg allow_unmapped "$ALLOW_UNMAPPED" \
@@ -400,10 +411,10 @@ write_wrapper() {
 CONFIG_DIR="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")/.." && pwd)"
 APORT_REPO_ROOT="\$(cat "\$CONFIG_DIR/.aport-repo" 2>/dev/null)"
 [ -z "\$APORT_REPO_ROOT" ] && { echo "Error: \$CONFIG_DIR/.aport-repo missing. Re-run bin/openclaw from the guardrails repo." >&2; exit 1; }
-export OPENCLAW_PASSPORT_FILE="\${OPENCLAW_PASSPORT_FILE:-\$CONFIG_DIR/passport.json}"
-export OPENCLAW_DECISION_FILE="\${OPENCLAW_DECISION_FILE:-\$CONFIG_DIR/decision.json}"
-export OPENCLAW_AUDIT_LOG="\${OPENCLAW_AUDIT_LOG:-\$CONFIG_DIR/audit.log}"
-export OPENCLAW_KILL_SWITCH="\${OPENCLAW_KILL_SWITCH:-\$CONFIG_DIR/kill-switch}"
+export OPENCLAW_PASSPORT_FILE="\${OPENCLAW_PASSPORT_FILE:-\$CONFIG_DIR/aport/passport.json}"
+export OPENCLAW_DECISION_FILE="\${OPENCLAW_DECISION_FILE:-\$CONFIG_DIR/aport/decision.json}"
+export OPENCLAW_AUDIT_LOG="\${OPENCLAW_AUDIT_LOG:-\$CONFIG_DIR/aport/audit.log}"
+export OPENCLAW_KILL_SWITCH="\${OPENCLAW_KILL_SWITCH:-\$CONFIG_DIR/aport/kill-switch}"
 exec "\$APORT_REPO_ROOT/bin/$name" "\$@"
 WRAP
     chmod +x "$CONFIG_DIR/.skills/$name"
@@ -495,47 +506,15 @@ fi
 # 3b. Install APort skill so OpenClaw loads it (managed skill: ~/.openclaw/skills)
 #     OpenClaw loads from: workspace/skills, then ~/.openclaw/skills, then bundled
 #     See https://docs.openclaw.ai/tools/skills
+#     Copy from repo so installed skill matches skills/aport-guardrail/SKILL.md (single source of truth)
 SKILL_DIR="$CONFIG_DIR/skills/aport-guardrail"
+REPO_SKILL="$REPO_ROOT/skills/aport-guardrail/SKILL.md"
 mkdir -p "$SKILL_DIR"
-GUARDRAIL_PATH="$CONFIG_DIR/.skills/aport-guardrail.sh"
-cat > "$SKILL_DIR/SKILL.md" << SKILL
----
-name: aport-guardrail
-description: Pre-action authorization for tools (bash, messaging, git, etc.). Call before effectful actions.
-metadata: {"openclaw":{"requires":{"bins":["jq"]},"emoji":"🛡️"}}
----
-
-# APort Guardrail (pre-action authorization)
-
-Before running **effectful tools** (system commands, messaging, git, data export), call this guardrail so policy and passport are checked.
-
-## Invocation
-
-Run the script with **tool name** and **context JSON**:
-
-\`\`\`bash
-$GUARDRAIL_PATH <tool_name> '<context_json>'
-\`\`\`
-
-- **Exit 0** = allow (proceed with the action)
-- **Exit 1** = deny (read \`$CONFIG_DIR/decision.json\` for reasons)
-
-## Tool names (map to policy packs)
-
-| When you're about to…        | Use tool_name              |
-|-----------------------------|----------------------------|
-| Run a shell command / bash  | \`system.command.execute\` |
-| Send a message (WhatsApp…)  | \`messaging.message.send\` |
-| Create/merge PR, git push   | \`git.create_pr\` / \`git.merge\` |
-| MCP tool call               | \`mcp.tool.execute\`       |
-| Data export                 | \`data.export\`            |
-
-Context must be valid JSON, e.g. \`'{"command":"ls"}' \` or \`'{"channel":"whatsapp","to":"+1234567890"}'\`.
-
-## Optional (API mode)
-
-To use APort API (self-hosted or cloud), use \`$CONFIG_DIR/.skills/aport-guardrail-api.sh\` with the same args and set \`APORT_API_URL\` if needed.
-SKILL
+if [ -f "$REPO_SKILL" ]; then
+    cp "$REPO_SKILL" "$SKILL_DIR/SKILL.md"
+else
+    echo "  ⚠️  Repo SKILL.md not found at $REPO_SKILL; skipping skill install." >&2
+fi
 echo "✅ APort skill installed in $CONFIG_DIR/skills/aport-guardrail/"
 echo "   OpenClaw will load it (managed skill). Use it before effectful actions."
 echo

--- a/docs/QUICKSTART_OPENCLAW_PLUGIN.md
+++ b/docs/QUICKSTART_OPENCLAW_PLUGIN.md
@@ -68,7 +68,7 @@ If you prefer manual installation:
 ### 1. Create Passport
 
 ```bash
-./bin/aport-create-passport.sh --output ~/.openclaw/passport.json
+./bin/aport-create-passport.sh --output ~/.openclaw/aport/passport.json
 ```
 
 ### 2. Install Plugin
@@ -92,7 +92,7 @@ plugins:
         mode: api
 
         # Passport file location
-        passportFile: ~/.openclaw/passport.json
+        passportFile: ~/.openclaw/aport/passport.json
 
         # For local mode: path to guardrail script
         guardrailScript: ~/.openclaw/.skills/aport-guardrail-bash.sh
@@ -120,8 +120,8 @@ mkdir -p ~/.openclaw/.skills
 cat > ~/.openclaw/.skills/aport-guardrail-bash.sh << 'EOF'
 #!/bin/bash
 APORT_REPO_ROOT="/path/to/aport-agent-guardrails"
-export OPENCLAW_PASSPORT_FILE="${OPENCLAW_PASSPORT_FILE:-$HOME/.openclaw/passport.json}"
-export OPENCLAW_DECISION_FILE="${OPENCLAW_DECISION_FILE:-$HOME/.openclaw/decision.json}"
+export OPENCLAW_PASSPORT_FILE="${OPENCLAW_PASSPORT_FILE:-$HOME/.openclaw/aport/passport.json}"
+export OPENCLAW_DECISION_FILE="${OPENCLAW_DECISION_FILE:-$HOME/.openclaw/aport/decision.json}"
 exec "$APORT_REPO_ROOT/bin/aport-guardrail-bash.sh" "$@"
 EOF
 chmod +x ~/.openclaw/.skills/aport-guardrail-bash.sh
@@ -204,7 +204,7 @@ Expected: Tool blocked with message:
 Policy: system.command.execute.v1
 Reason: Command exceeds allowed scope
 
-To override, update your passport at: ~/.openclaw/passport.json
+To override, update your passport at: ~/.openclaw/aport/passport.json (or ~/.openclaw/passport.json for legacy)
 ```
 
 ---
@@ -220,7 +220,7 @@ To override, update your passport at: ~/.openclaw/passport.json
 ```yaml
 config:
   mode: api
-  passportFile: ~/.openclaw/passport.json
+  passportFile: ~/.openclaw/aport/passport.json
   apiUrl: https://api.aport.io
 ```
 Set `APORT_API_KEY` in the environment only if your API requires auth.
@@ -239,7 +239,7 @@ Set `APORT_API_KEY` in the environment only if your API requires auth.
 ```yaml
 config:
   mode: local
-  passportFile: ~/.openclaw/passport.json
+  passportFile: ~/.openclaw/aport/passport.json
   guardrailScript: ~/.openclaw/.skills/aport-guardrail-bash.sh
 ```
 
@@ -287,7 +287,7 @@ Check:
 
 ### Guardrail DENY / `oap.passport_version_mismatch`
 
-If the guardrail denies every call and `~/.openclaw/decision.json` shows reason `oap.passport_version_mismatch` ("Passport spec version is 'unknown', expected 'oap/1.0'"):
+If the guardrail denies every call and `~/.openclaw/aport/decision.json` (or `~/.openclaw/decision.json`) shows reason `oap.passport_version_mismatch` ("Passport spec version is 'unknown', expected 'oap/1.0'"):
 
 1. **Passport must have `spec_version: "oap/1.0"`** (OAP spec). If your passport has only `"version": "1.0.0"` in metadata and no top-level `spec_version`, it was created by an older or non–spec-compliant tool.
 2. **Limits must be nested per capability.** The verifier expects e.g. `limits["system.command.execute"]` with `allowed_commands`, `blocked_patterns`, not a flat `limits.allowed_commands` at the top level.
@@ -314,7 +314,7 @@ plugins:
       enabled: true
       config:
         mode: api
-        passportFile: ~/.openclaw/passport.json
+        passportFile: ~/.openclaw/aport/passport.json
         apiUrl: https://api.aport.io
         failClosed: true
 ```
@@ -332,7 +332,7 @@ plugins:
         mode: api
 
         # Passport file location
-        passportFile: ~/.openclaw/passport.json
+        passportFile: ~/.openclaw/aport/passport.json
 
         # For local mode: path to guardrail script
         guardrailScript: ~/.openclaw/.skills/aport-guardrail-bash.sh
@@ -355,7 +355,7 @@ plugins:
       enabled: true
       config:
         mode: local
-        passportFile: ~/.openclaw/passport.json
+        passportFile: ~/.openclaw/aport/passport.json
         guardrailScript: ~/.openclaw/.skills/aport-guardrail-bash.sh
         failClosed: true
 ```
@@ -432,7 +432,7 @@ plugins:
 2. **Choose "yes"** when prompted to install the plugin.
 3. **Start OpenClaw** with the generated config: `openclaw gateway start --config <your-config-dir>/config.yaml` (e.g. `~/.openclaw/config.yaml`).
 4. **Test enforcement:** Run the agent; try an allowed action (e.g. `node --version`) and one that should be blocked by your passport (e.g. `rm -rf /`). The plugin blocks before the tool runs.
-5. **Customize passport:** Edit `<config-dir>/passport.json` to adjust limits and allowed commands.
+5. **Customize passport:** Edit `<config-dir>/aport/passport.json` (or `<config-dir>/passport.json` for legacy) to adjust limits and allowed commands.
 
 ---
 
@@ -461,7 +461,7 @@ plugins:
 | Step | What happens |
 |------|----------------|
 | You run `./bin/openclaw` | Script asks for config dir, creates passport, installs plugin, writes `config.yaml`, installs wrappers in `<config-dir>/.skills/`, and **updates the passport** with default `allowed_commands` (bash, sh, ls, mkdir, npm, etc.) so normal exec works. |
-| `config.yaml` | Contains `passportFile` and `guardrailScript` pointing to `<config-dir>/passport.json` and `<config-dir>/.skills/aport-guardrail-bash.sh`. |
+| `config.yaml` | Contains `passportFile` and `guardrailScript` pointing to `<config-dir>/aport/passport.json` and `<config-dir>/.skills/aport-guardrail-bash.sh`. |
 | Passport allowlist | The installer sets `allowed_commands: ["*"]` automatically. No manual editing needed unless you want to restrict commands. |
 | Wrapper script | `<config-dir>/.skills/aport-guardrail-bash.sh` is a small script that calls this repo’s `bin/aport-guardrail-bash.sh` with the same args and env (passport path, etc.). |
 | You start OpenClaw | `openclaw gateway start --config <config-dir>/config.yaml` (or use that config when running the agent). |

--- a/extensions/openclaw-aport/README.md
+++ b/extensions/openclaw-aport/README.md
@@ -61,8 +61,8 @@ plugins:
         # Mode: "local" (use guardrail script) or "api" (use APort cloud API)
         mode: local
 
-        # Passport file location
-        passportFile: ~/.openclaw/passport.json
+        # Passport file location (in aport/ subdir; legacy: ~/.openclaw/passport.json)
+        passportFile: ~/.openclaw/aport/passport.json
 
         # For local mode: path to guardrail script
         guardrailScript: ~/.openclaw/.skills/aport-guardrail-bash.sh
@@ -87,7 +87,7 @@ plugins:
 ## exec, allowed_commands, and unmapped tools
 
 - **exec** is OpenClaw’s main “run something” tool: it can run the guardrail script (we delegate to the inner tool) or a real shell command (e.g. `mkdir`, `npm install`). By default we map **exec** → **system.command.execute.v1** and check the **command** against your passport’s **limits.system.command.execute.allowed_commands**. If `mkdir` (or another command) is not in that list, the policy denies with `oap.command_not_allowed`.
-- **Fix:** Add every command you need to **allowed_commands** in your passport (e.g. `mkdir`, `cp`, `ls`, `cat`, `echo`, `pwd`, `mv`, `touch`, `npx`, `open`). Re-run the passport wizard to get an expanded default list, or edit `~/.openclaw/passport.json` and add to `limits.system.command.execute.allowed_commands`. If the guardrail is ever run via **exec** (e.g. a skill runs `bash ~/.openclaw/.skills/aport-guardrail.sh ...`), include **`bash`** (or the full script path) in **allowed_commands** so that invocation is allowed; the wizard default includes `bash` and `sh`.
+- **Fix:** Add every command you need to **allowed_commands** in your passport (e.g. `mkdir`, `cp`, `ls`, `cat`, `echo`, `pwd`, `mv`, `touch`, `npx`, `open`). Re-run the passport wizard to get an expanded default list, or edit `~/.openclaw/aport/passport.json` (or `~/.openclaw/passport.json` for legacy) and add to `limits.system.command.execute.allowed_commands`. If the guardrail is ever run via **exec** (e.g. a skill runs `bash ~/.openclaw/.skills/aport-guardrail.sh ...`), include **`bash`** (or the full script path) in **allowed_commands** so that invocation is allowed; the wizard default includes `bash` and `sh`.
 - **Optional:** Set **mapExecToPolicy: false** in plugin config so **exec** is not mapped; then exec is treated as an unmapped tool and allowed (no command allowlist). Use only if you rely on other controls; this disables guardrail protection for shell commands.
 - **read, write, edit, etc.** (OpenClaw file/browser tools) have **no policy mapping** in this plugin, so they are **allowed** by default when `allowUnmappedTools` is true. A “read failed: ENOENT” is the tool failing (e.g. file not found), not the guardrail blocking. Tool→policy mapping and passport limits are documented in [TOOL_POLICY_MAPPING.md](../../docs/TOOL_POLICY_MAPPING.md) and [OPENCLAW_TOOLS_AND_POLICIES.md](../../docs/OPENCLAW_TOOLS_AND_POLICIES.md).
 

--- a/extensions/openclaw-aport/index.js
+++ b/extensions/openclaw-aport/index.js
@@ -16,7 +16,7 @@
  *         enabled: true
  *         config:
  *           mode: local        # "local" | "api"
- *           passportFile: ~/.openclaw/passport.json   # Omit when using agentId (hosted)
+ *           passportFile: ~/.openclaw/aport/passport.json   # Omit when using agentId (hosted)
  *           agentId: ap_...     # Optional: hosted passport from aport.io (API fetches passport)
  *           guardrailScript: ~/.openclaw/.skills/aport-guardrail-bash.sh
  *           apiUrl: https://api.aport.io  # For API mode
@@ -24,7 +24,8 @@
  *           failClosed: true               # Block on error
  *
  * Decisions (local mode): Written to <config_dir>/decisions/<timestamp>-<id>.json and left for
- * audit. The guardrail script also appends a one-line summary to <config_dir>/audit.log. Decisions
+ * audit. The guardrail script also appends a one-line summary to <config_dir>/audit.log (when
+ * passport is in config/aport/, audit lives in config/aport/audit.log). Decisions
  * follow OAP v1.0 schema (see agent-passport spec/oap/decision-schema.json). Local mode uses
  * unsigned/local-unsigned; API mode can return signed decisions (chained audit in agent-passport).
  */
@@ -44,7 +45,7 @@ export default function (api) {
   const mode = config.mode || "local";
   const agentId = config.agentId || null;
   const passportFile = expandPath(
-    config.passportFile || "~/.openclaw/passport.json",
+    config.passportFile || "~/.openclaw/aport/passport.json",
   );
   const guardrailScript = expandPath(
     config.guardrailScript || "~/.openclaw/.skills/aport-guardrail-bash.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "bin": {
     "agent-guardrails": "./bin/openclaw",
@@ -40,6 +40,7 @@
     "external/",
     "templates/",
     "policies/",
+    "skills/",
     "docs/",
     "LICENSE",
     "README.md"

--- a/skills/aport-guardrail/SKILL.md
+++ b/skills/aport-guardrail/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: aport-guardrail
+description: Pre-action authorization for tools (bash, messaging, git, MCP, data export). The APort policy engine allows or denies every tool call deterministically before it runs.
+homepage: https://aport.io
+metadata: {"openclaw":{"requires":{"bins":["jq"]}}}
+---
+
+# APort Guardrail
+
+Pre-action authorization for OpenClaw: every tool call is checked **before** it runs. Run the installer once; the OpenClaw plugin then enforces policy on every tool call automatically. You do **not** run the guardrail script yourself.
+
+> Requires: Node 18+, jq. Install with `npx @aporthq/agent-guardrails` or `./bin/openclaw` from the repo.
+
+## Installation
+
+```bash
+# Recommended (no clone needed)
+npx @aporthq/agent-guardrails
+
+# Hosted passport: skip the wizard by passing agent_id from aport.io
+npx @aporthq/agent-guardrails <agent_id>
+```
+
+Get a Hosted Passport **agent_id** at [aport.io](https://aport.io/builder/create/) after creating a passport there. __*OPTIONAL*__
+
+From the repo (clone first): [github.com/aporthq/aport-agent-guardrails](https://github.com/aporthq/aport-agent-guardrails) — then run `./bin/openclaw` or `./bin/openclaw <agent_id>` from the repo root.
+
+You can preview your local passport at `~/.openclaw/aport/passport.json` (or `<config-dir>/aport/passport.json` if you chose a different config dir; legacy installs may use `<config-dir>/passport.json`).
+
+The installer is interactive: it sets your config dir, passport (local or hosted), installs the APort OpenClaw plugin, writes config, and installs wrappers. **After it finishes, nothing else is required**—start OpenClaw (or use the running gateway); the plugin enforces before every tool call.
+
+Wrappers (default config dir `~/.openclaw`): `~/.openclaw/.skills/aport-guardrail.sh` (local), `~/.openclaw/.skills/aport-guardrail-api.sh` (API/hosted). The plugin uses these; you don’t call them unless testing.
+
+## Usage
+
+**Normal use:** Run the installer once. After that, nothing to run manually—the plugin enforces before each tool call automatically.
+
+**Optional — direct script calls** (e.g. testing or other automations):
+
+```bash
+~/.openclaw/.skills/aport-guardrail.sh system.command.execute '{"command":"ls"}'
+~/.openclaw/.skills/aport-guardrail.sh messaging.message.send '{"channel":"whatsapp","to":"+15551234567"}'
+```
+
+- Exit 0 = ALLOW (tool may proceed)
+- Exit 1 = DENY (see `<config-dir>/aport/decision.json` or `<config-dir>/decision.json` for reason codes)
+
+For API mode / hosted passports:
+
+```bash
+APORT_API_URL=https://api.aport.io ~/.openclaw/.skills/aport-guardrail-api.sh system.command.execute '{"command":"ls"}'
+```
+
+## Tool name mapping
+
+| When you're about to…        | Use tool_name               |
+|------------------------------|-----------------------------|
+| Run shell commands           | `system.command.execute`    |
+| Send WhatsApp/email/etc.     | `messaging.message.send`    |
+| Create/merge PRs             | `git.create_pr`, `git.merge`|
+| Call MCP tools               | `mcp.tool.execute`          |
+| Export data / files          | `data.export`               |
+
+Context must be valid JSON, e.g. `'{"command":"ls"}'` or `'{"channel":"whatsapp","to":"+1..."}'`.
+
+## Why this skill?
+
+- **Deterministic** – runs in `before_tool_call`; the agent cannot skip it.
+- **Structured policy** – backed by [Open Agent Passport (OAP) v1.0](https://github.com/aporthq/aport-spec/tree/main) and policy packs.
+- **Fail-closed** – if the guardrail errors, the tool is blocked.
+- **Audit-ready** – decisions are logged (local JSON or APort API for signed receipts).
+
+Pair it with other threat-detection tooling if needed; enforce policy through this guardrail so unsafe actions never run.
+
+## OpenClaw docs
+
+- [CLI: skills](https://docs.openclaw.ai/cli/skills) — list, info, check
+- [Skills](https://docs.openclaw.ai/tools/skills) — loading, precedence, plugins, ClawHub
+- [Skills config](https://docs.openclaw.ai/tools/skills-config) — schema and overrides
+- [ClawHub](https://docs.openclaw.ai/tools/clawhub) — install, sync, update skills

--- a/tests/fixtures/decision.json
+++ b/tests/fixtures/decision.json
@@ -1,0 +1,19 @@
+{
+  "decision_id": "local-error-1771291655471",
+  "policy_id": "system.command.execute.v1",
+  "passport_id": "unknown",
+  "owner_id": "unknown",
+  "assurance_level": "L0",
+  "allow": false,
+  "reasons": [
+    {
+      "code": "oap.evaluation_error",
+      "message": "API request failed (404): {\"error\":\"passport_not_found\",\"message\":\"Passport with the specified agent ID was not found\",\"details\":{\"requestId\":\"policy_1771291653775_ivjmlj\",\"agent_id\":\"ap_8955f5450cd542fe8f67bbbf07c3e103\"}}"
+    }
+  ],
+  "issued_at": "2026-02-17T01:27:35.471Z",
+  "expires_at": "2026-02-17T02:27:35.471Z",
+  "passport_digest": "sha256:error",
+  "signature": "ed25519:unsigned",
+  "kid": "oap:local:error"
+}

--- a/tests/test-openclaw-hosted-flow.sh
+++ b/tests/test-openclaw-hosted-flow.sh
@@ -63,7 +63,7 @@ if grep -q "passportFile:.*passport.json" "$CONFIG_DIR/config.yaml" 2>/dev/null;
 fi
 echo "  ✅ config does not set passportFile (hosted)"
 
-if [ -f "$CONFIG_DIR/passport.json" ]; then
+if [ -f "$CONFIG_DIR/passport.json" ] || [ -f "$CONFIG_DIR/aport/passport.json" ]; then
     echo "FAIL: hosted flow must not create local passport.json" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- APort data in `config_dir/aport/` (passport, decision, audit, kill-switch); backward compatible with legacy paths
- `bin/aport-resolve-paths.sh` for DRY path resolution; guardrail-bash, guardrail-api, status source it
- Installer copies `skills/aport-guardrail/SKILL.md` from repo (single source of truth)
- SKILL.md: no shield, agent_id option, OpenClaw docs links; clarify no manual guardrail run
- Bump to **1.0.5**; CHANGELOG; package.json includes `skills/`

## Flow
Merge this (staging), then open PR **staging → main**. You merge main; then tag `v1.0.5`.

Made with [Cursor](https://cursor.com)