### PR TITLE
chore(release): v1.0.10 - deprecated wrapper and npx fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish deprecated wrapper package (agent-guardrails → aport-agent-guardrails)
+        run: npm publish -w @aporthq/agent-guardrails --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-python:
     runs-on: ubuntu-latest
     env:

--- a/bin/lib/error.sh
+++ b/bin/lib/error.sh
@@ -188,7 +188,7 @@ get_resolution() {
             echo "Use absolute paths without parent directory references (../ or /..). This is a security feature to prevent path traversal attacks."
             ;;
         "$ERROR_PASSPORT_NOT_FOUND")
-            echo "Create a passport by running: npx @aporthq/agent-guardrails openclaw. See: https://github.com/aporthq/agent-guardrails#passport-setup"
+            echo "Create a passport by running: npx @aporthq/aport-agent-guardrails openclaw. See: https://github.com/aporthq/agent-guardrails#passport-setup"
             ;;
         "$ERROR_PASSPORT_MISSING_CAP")
             echo "Request capability be added to passport or generate new passport with required capabilities."
@@ -206,7 +206,7 @@ get_resolution() {
             echo "Wait for rate limit to reset, reduce request frequency, or use local evaluation mode instead of API mode."
             ;;
         "$ERROR_MISCONFIGURED")
-            echo "Run setup: npx @aporthq/agent-guardrails <framework>. Check passport exists at ~/.openclaw/passport.json"
+            echo "Run setup: npx @aporthq/aport-agent-guardrails <framework>. Check passport exists at ~/.openclaw/passport.json"
             ;;
         *)
             echo ""

--- a/bin/openclaw
+++ b/bin/openclaw
@@ -29,9 +29,26 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 APORT_PLUGIN_PATH="$REPO_ROOT/extensions/openclaw-aport"
 DEFAULT_CONFIG="${OPENCLAW_HOME:-$HOME/.openclaw}"
 
-# Parse agent_id from command line
+# Parse command line arguments
 HOSTED_AGENT_ID=""
 if [ -n "$1" ]; then
+    # Handle help flags
+    if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+        echo "Usage: $0 [agent_id]"
+        echo ""
+        echo "Interactive setup for APort + OpenClaw integration."
+        echo ""
+        echo "Arguments:"
+        echo "  agent_id    Optional hosted passport ID from aport.io (e.g., ap_abc123...)"
+        echo "              If provided, uses hosted passport; otherwise runs passport wizard."
+        echo ""
+        echo "Examples:"
+        echo "  $0                                    # Local passport (wizard)"
+        echo "  $0 ap_fa2f6d53bb5b4c98b9af0124285b6e0f   # Hosted passport"
+        echo ""
+        echo "See: https://github.com/aporthq/aport-agent-guardrails/tree/main/docs"
+        exit 0
+    fi
     # Validate agent_id format (ap_ followed by 32 hex chars)
     if [[ "$1" =~ ^ap_[a-f0-9]{32}$ ]]; then
         HOSTED_AGENT_ID="$1"
@@ -39,6 +56,8 @@ if [ -n "$1" ]; then
         echo "❌ Invalid agent_id format: $1"
         echo "   Expected: ap_[32 hex characters]"
         echo "   Example: ap_fa2f6d53bb5b4c98b9af0124285b6e0f"
+        echo ""
+        echo "Run '$0 --help' for usage information."
         exit 1
     fi
 fi

--- a/docs/development/ERROR_CODES.md
+++ b/docs/development/ERROR_CODES.md
@@ -174,7 +174,7 @@ Request ID: req_1234567890
 **Resolution**:
 ```bash
 # Create a passport
-npx @aporthq/agent-guardrails openclaw
+npx @aporthq/aport-agent-guardrails openclaw
 # Or
 aport-create-passport.sh
 ```
@@ -373,7 +373,7 @@ aport-create-passport.sh
 **Cause**: No config file at expected locations
 
 **Resolution**:
-- Run setup: `npx @aporthq/agent-guardrails <framework>`
+- Run setup: `npx @aporthq/aport-agent-guardrails <framework>`
 - Create config manually in `~/.aport/<framework>/config.yaml`
 
 **Expected Locations**:
@@ -522,7 +522,7 @@ ls -la ~/.openclaw/passport.json
 ls -la ~/.openclaw/.skills/aport-guardrail.sh
 
 # Run setup if missing
-npx @aporthq/agent-guardrails openclaw
+npx @aporthq/aport-agent-guardrails openclaw
 ```
 
 **Legacy Mode**: Set `APORT_FAIL_OPEN_WHEN_MISSING_CONFIG=1` to allow by default (not recommended)

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,40 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.7",
+      "version": "1.0.10",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "bin": {
+        "agent-guardrails": "bin/agent-guardrails",
+        "aport": "bin/openclaw",
+        "aport-agent-guardrails": "bin/agent-guardrails",
+        "aport-guardrail": "bin/aport-guardrail.sh"
+      },
+      "devDependencies": {
+        "@changesets/cli": "^2.27.0",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aporthq/agent-guardrails": {
+      "resolved": "packages/deprecated-agent-guardrails",
+      "link": true
+    },
+    "node_modules/@aporthq/aport-agent-guardrails": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@aporthq/aport-agent-guardrails/-/aport-agent-guardrails-1.0.9.tgz",
+      "integrity": "sha512-Cnn+T8KOgHeGavnIk2xHNBrR5MNdNcjnKS0+xZ0i21zOGMBmQ1cPshqobbfoOhTX3SHd4FlFDVQtkWPs1K3N+w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -16,11 +44,6 @@
         "agent-guardrails": "bin/agent-guardrails",
         "aport": "bin/openclaw",
         "aport-guardrail": "bin/aport-guardrail.sh"
-      },
-      "devDependencies": {
-        "@changesets/cli": "^2.27.0",
-        "@types/node": "^20.0.0",
-        "typescript": "^5.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5075,7 +5098,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -5094,7 +5117,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0"
@@ -5106,7 +5129,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0"
@@ -5116,9 +5139,26 @@
         "typescript": "^5.0.0"
       }
     },
+    "packages/deprecated-agent-guardrails": {
+      "name": "@aporthq/agent-guardrails",
+      "version": "1.0.10",
+      "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aporthq/aport-agent-guardrails": "^1.0.9"
+      },
+      "bin": {
+        "agent-guardrails": "bin.js",
+        "aport": "bin.js",
+        "aport-guardrail": "bin.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0",
@@ -5134,7 +5174,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "packages/*"
   ],
   "bin": {
+    "aport-agent-guardrails": "./bin/agent-guardrails",
     "agent-guardrails": "./bin/agent-guardrails",
     "aport": "./bin/openclaw",
     "aport-guardrail": "./bin/aport-guardrail.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/deprecated-agent-guardrails/README.md
+++ b/packages/deprecated-agent-guardrails/README.md
@@ -1,0 +1,41 @@
+# @aporthq/agent-guardrails [DEPRECATED]
+
+> ⚠️ **This package has been renamed to `@aporthq/aport-agent-guardrails`**
+
+## Migration
+
+This package has been renamed for better SEO and discoverability.
+
+**Old:**
+```bash
+npm install @aporthq/agent-guardrails
+npx @aporthq/agent-guardrails
+```
+
+**New:**
+```bash
+npm install @aporthq/aport-agent-guardrails
+npx @aporthq/aport-agent-guardrails
+```
+
+## What This Package Does
+
+This is a **compatibility wrapper** that forwards to the new package. It will show a deprecation warning and then execute the new package.
+
+**All functionality is identical** - this is just a renamed package.
+
+## Timeline
+
+- **Now**: This wrapper allows existing users to continue using the old name
+- **Future**: This package will be unpublished once adoption of the new name is complete
+
+## Documentation
+
+See the new package for full documentation:
+- npm: https://www.npmjs.com/package/@aporthq/aport-agent-guardrails
+- GitHub: https://github.com/aporthq/aport-agent-guardrails
+
+## Support
+
+If you have any issues with migration, please open an issue:
+https://github.com/aporthq/aport-agent-guardrails/issues

--- a/packages/deprecated-agent-guardrails/bin.js
+++ b/packages/deprecated-agent-guardrails/bin.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+// Deprecation wrapper bin for @aporthq/agent-guardrails → @aporthq/aport-agent-guardrails
+
+console.warn('\n⚠️  DEPRECATION WARNING\n');
+console.warn('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.warn('Package @aporthq/agent-guardrails has been RENAMED to:');
+console.warn('  @aporthq/aport-agent-guardrails');
+console.warn('');
+console.warn('Please update your usage:');
+console.warn('  npx @aporthq/aport-agent-guardrails');
+console.warn('');
+console.warn('This wrapper will be removed in a future version.');
+console.warn('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+// Forward to the new package's bin
+const { spawn } = require('child_process');
+const path = require('path');
+
+// Find the new package's bin directory
+const newPackageBin = path.join(
+  require.resolve('@aporthq/aport-agent-guardrails/package.json'),
+  '..',
+  'bin',
+  'agent-guardrails'
+);
+
+// Forward all arguments to the new package
+const child = spawn(newPackageBin, process.argv.slice(2), {
+  stdio: 'inherit',
+  shell: false
+});
+
+child.on('exit', (code) => {
+  process.exit(code);
+});

--- a/packages/deprecated-agent-guardrails/index.js
+++ b/packages/deprecated-agent-guardrails/index.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+// Deprecation wrapper for @aporthq/agent-guardrails → @aporthq/aport-agent-guardrails
+
+console.warn('\n⚠️  DEPRECATION WARNING\n');
+console.warn('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+console.warn('Package @aporthq/agent-guardrails has been RENAMED to:');
+console.warn('  @aporthq/aport-agent-guardrails');
+console.warn('');
+console.warn('Please update your dependencies:');
+console.warn('  npm install @aporthq/aport-agent-guardrails');
+console.warn('');
+console.warn('This wrapper will be removed in a future version.');
+console.warn('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+// Re-export everything from the new package
+module.exports = require('@aporthq/aport-agent-guardrails');

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@aporthq/agent-guardrails",
+  "version": "1.0.10",
+  "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
+  "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
+  "main": "index.js",
+  "bin": {
+    "agent-guardrails": "bin.js",
+    "aport": "bin.js",
+    "aport-guardrail": "bin.js"
+  },
+  "keywords": [
+    "deprecated",
+    "aport",
+    "agent",
+    "guardrails",
+    "security"
+  ],
+  "author": "APort Technologies Inc.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aporthq/aport-agent-guardrails.git",
+    "directory": "packages/deprecated-agent-guardrails"
+  },
+  "dependencies": {
+    "@aporthq/aport-agent-guardrails": "^1.0.9"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/python/aport_guardrails/cli.py
+++ b/python/aport_guardrails/cli.py
@@ -28,7 +28,7 @@ async def run(args: argparse.Namespace) -> None:
     if args.command == "setup":
         _print_setup_next_steps(args.framework)
     elif args.command == "status":
-        print("Status: run `npx @aporthq/agent-guardrails` or see docs for guardrail status commands.")
+        print("Status: run `npx @aporthq/aport-agent-guardrails` or see docs for guardrail status commands.")
     else:
         print(f"Unknown command: {args.command}")
 
@@ -39,17 +39,17 @@ def _print_setup_next_steps(framework: str) -> None:
     print()
     if framework == "openclaw":
         print("Run the full wizard and plugin install:")
-        print("  npx @aporthq/agent-guardrails openclaw")
-        print("  (Optional: pass an agent_id for hosted passport: npx @aporthq/agent-guardrails openclaw <agent_id>)")
+        print("  npx @aporthq/aport-agent-guardrails openclaw")
+        print("  (Optional: pass an agent_id for hosted passport: npx @aporthq/aport-agent-guardrails openclaw <agent_id>)")
     elif framework == "cursor":
         print("Run the installer (writes ~/.cursor/hooks.json), then restart Cursor:")
-        print("  npx @aporthq/agent-guardrails cursor")
+        print("  npx @aporthq/aport-agent-guardrails cursor")
     elif framework == "langchain":
-        print("1. Run wizard and config:  npx @aporthq/agent-guardrails langchain")
+        print("1. Run wizard and config:  npx @aporthq/aport-agent-guardrails langchain")
         print("2. Install Python adapter: pip install aport-agent-guardrails-langchain")
         print("3. Framework setup:        aport-langchain setup")
     elif framework == "crewai":
-        print("1. Run wizard and config:  npx @aporthq/agent-guardrails crewai")
+        print("1. Run wizard and config:  npx @aporthq/aport-agent-guardrails crewai")
         print("2. Install Python adapter: pip install aport-agent-guardrails-crewai")
         print("3. Framework setup:        aport-crewai setup")
     print()

--- a/python/aport_guardrails/core/cli_common.py
+++ b/python/aport_guardrails/core/cli_common.py
@@ -20,7 +20,7 @@ def run_wizard(framework: str) -> bool:
     """Run passport wizard via npx agent-guardrails. Returns True if run successfully."""
     try:
         r = subprocess.run(
-            ["npx", "--yes", "@aporthq/agent-guardrails", f"--framework={framework}"],
+            ["npx", "--yes", "@aporthq/aport-agent-guardrails", f"--framework={framework}"],
             check=False,
             timeout=120,
             capture_output=True,
@@ -52,11 +52,11 @@ def run_setup(
         print(f"[aport] Config exists: {config_path}")
 
     if not ci and not no_wizard:
-        print(f"[aport] Run the passport wizard with: npx @aporthq/agent-guardrails --framework={framework}")
+        print(f"[aport] Run the passport wizard with: npx @aporthq/aport-agent-guardrails --framework={framework}")
         if run_wizard(framework):
             print("[aport] Wizard completed.")
         else:
-            print(f"[aport] Install passport: npx @aporthq/agent-guardrails --framework={framework}")
+            print(f"[aport] Install passport: npx @aporthq/aport-agent-guardrails --framework={framework}")
 
     print("")
     for line in next_steps_lines:

--- a/python/aport_guardrails/core/errors.py
+++ b/python/aport_guardrails/core/errors.py
@@ -268,7 +268,7 @@ RESOLUTIONS = {
         "This is a security feature to prevent path traversal attacks."
     ),
     ErrorCode.PASSPORT_NOT_FOUND: (
-        "Create a passport by running: npx @aporthq/agent-guardrails openclaw\n"
+        "Create a passport by running: npx @aporthq/aport-agent-guardrails openclaw\n"
         "See: https://github.com/aporthq/agent-guardrails#passport-setup"
     ),
     ErrorCode.PASSPORT_MISSING_CAPABILITY: (
@@ -290,7 +290,7 @@ RESOLUTIONS = {
         "or use local evaluation mode instead of API mode."
     ),
     ErrorCode.MISCONFIGURED: (
-        "Run setup: npx @aporthq/agent-guardrails <framework>. "
+        "Run setup: npx @aporthq/aport-agent-guardrails <framework>. "
         "Check passport exists at ~/.openclaw/passport.json and guardrail script at ~/.openclaw/.skills/aport-guardrail.sh"
     ),
 }

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.9"
+version = "1.0.10"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.9"
+version = "1.0.10"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.9"
+version = "1.0.10"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
Release version 1.0.10 with backward compatibility wrapper and critical npx fixes.

## Version: 1.0.9 → 1.0.10

## Features

**Deprecated Package Wrapper**
- Created `@aporthq/agent-guardrails` v1.0.10 as compatibility wrapper
- Depends on `@aporthq/aport-agent-guardrails` and forwards all functionality  
- Shows deprecation warning to guide migration
- Added to release workflow

**npx Fix** ✅
- Added `aport-agent-guardrails` bin entry (npm requirement for default execution)
- Fixes: `npx @aporthq/aport-agent-guardrails` now works correctly
- Previously failed with "could not determine executable to run"

**Package Migration**
- Updated all code references from old → new package name
- Affected: error messages, docs, Python CLI

**UX Improvements**
- Added `--help` flag to `bin/openclaw`
- Improved error messages with help hints

## Migration Path
Users can continue using `@aporthq/agent-guardrails` - they'll see deprecation warnings but everything works.

## Post-Release Action
Run: `npm deprecate @aporthq/agent-guardrails "Package renamed to @aporthq/aport-agent-guardrails for better SEO. Please migrate."`

## Testing
- ✅ Wrapper forwards correctly with deprecation warning
- ✅ npx command execution verified
- ✅ All 21 OpenClaw plugin tests pass