### PR TITLE
chore: update package-lock.json for v1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,40 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.7",
+      "version": "1.0.10",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "bin": {
+        "agent-guardrails": "bin/agent-guardrails",
+        "aport": "bin/openclaw",
+        "aport-agent-guardrails": "bin/agent-guardrails",
+        "aport-guardrail": "bin/aport-guardrail.sh"
+      },
+      "devDependencies": {
+        "@changesets/cli": "^2.27.0",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aporthq/agent-guardrails": {
+      "resolved": "packages/deprecated-agent-guardrails",
+      "link": true
+    },
+    "node_modules/@aporthq/aport-agent-guardrails": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@aporthq/aport-agent-guardrails/-/aport-agent-guardrails-1.0.9.tgz",
+      "integrity": "sha512-Cnn+T8KOgHeGavnIk2xHNBrR5MNdNcjnKS0+xZ0i21zOGMBmQ1cPshqobbfoOhTX3SHd4FlFDVQtkWPs1K3N+w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -16,11 +44,6 @@
         "agent-guardrails": "bin/agent-guardrails",
         "aport": "bin/openclaw",
         "aport-guardrail": "bin/aport-guardrail.sh"
-      },
-      "devDependencies": {
-        "@changesets/cli": "^2.27.0",
-        "@types/node": "^20.0.0",
-        "typescript": "^5.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5075,7 +5098,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -5094,7 +5117,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0"
@@ -5106,7 +5129,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0"
@@ -5116,9 +5139,26 @@
         "typescript": "^5.0.0"
       }
     },
+    "packages/deprecated-agent-guardrails": {
+      "name": "@aporthq/agent-guardrails",
+      "version": "1.0.10",
+      "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aporthq/aport-agent-guardrails": "^1.0.9"
+      },
+      "bin": {
+        "agent-guardrails": "bin.js",
+        "aport": "bin.js",
+        "aport-guardrail": "bin.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0",
@@ -5134,7 +5174,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.0",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.0"


### PR DESCRIPTION
## Summary
Updates package-lock.json to sync with package.json changes in v1.0.10.

## Changes
- Added  workspace to lock file
- Updated version references to 1.0.10
- Fixes CI error: "Missing: @aporthq/agent-guardrails@1.0.10 from lock file"

## CI Fix
Resolves the npm ci failure in PR #43