### PR TITLE
fix: sync package-lock.json with new workspace packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -113,6 +113,10 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@aporthq/aport-agent-guardrails-claude-code": {
+      "resolved": "packages/claude-code",
+      "link": true
     },
     "node_modules/@aporthq/aport-agent-guardrails-core": {
       "resolved": "packages/core",
@@ -15754,9 +15758,21 @@
         "zod": "^3.25 || ^4"
       }
     },
+    "packages/claude-code": {
+      "name": "@aporthq/aport-agent-guardrails-claude-code",
+      "version": "1.0.13",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.13"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -15775,10 +15791,10 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.0"
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.13"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -15787,10 +15803,10 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.0"
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.13"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -15799,7 +15815,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15816,10 +15832,10 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.0",
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.13",
         "@langchain/core": "^0.3.0"
       },
       "devDependencies": {
@@ -15832,10 +15848,10 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.0"
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.13"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- Regenerates package-lock.json to include claude-code package at 1.0.13 which was missing, causing npm ci to fail in CI.

## Test plan
- npm ci succeeds in CI
