### PR TITLE
fix: build core before workspace packages to resolve TS imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "changeset": "changeset",
     "version": "changeset version && node scripts/sync-version.mjs",
     "sync-version": "node scripts/sync-version.mjs",
-    "build": "npm run build --workspaces --if-present",
+    "build": "npm run build:core && npm run build --workspaces --if-present",
     "build:core": "npm run build -w @aporthq/aport-agent-guardrails-core",
     "release:version": "npm run version",
     "prepublishOnly": "npm run build 2>/dev/null || true"


### PR DESCRIPTION
Builds core package first so adapter packages can resolve TS imports.
