### PR TITLE
fix: use npm run build in CI to ensure core builds first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build and test Node packages
         run: |
-          npm run build --workspaces --if-present
+          npm run build
           npm run test -w @aporthq/aport-agent-guardrails-core -w @aporthq/aport-agent-guardrails-langchain
 
       - name: Run OpenClaw integration (Node)


### PR DESCRIPTION
CI workflow called npm run build --workspaces directly, bypassing the build script that ensures core compiles first. Changed to npm run build.