### PR TITLE
feat: add missing capabilities to passport wizard for Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.14] - 2026-03-11
+
+### Added
+- **Passport wizard: framework-aware capability defaults.** Each framework (`claude-code`, `cursor`, `crewai`, `langchain`, `n8n`) now gets sensible default capabilities during passport creation. Claude Code defaults include all capabilities; Cursor enables file, web, and session capabilities; other frameworks get appropriate subsets.
+- **Passport wizard: `agent.session.create` and `mcp.tool.execute` capabilities.** New interactive prompts for sub-agent spawning and MCP tool execution, with corresponding limits (`max_concurrent`, `allowed_servers`).
+- **Cursor hook: full hook event support.** Rewritten `aport-cursor-hook.sh` to handle all Cursor hook events:
+  - `beforeShellExecution` — shell command policy check
+  - `preToolUse` — routes Shell, Read, Write, Grep, Delete, Task, and MCP:\<name\> tools
+  - `beforeMCPExecution` — MCP server tool calls (detected by `server`/`url` field)
+  - `beforeReadFile` — allowed without evaluator (performance)
+  - `subagentStart` — sub-agent spawning policy check
+  - Legacy Copilot-style payloads still supported
+- **Cursor installer: 4 hook events.** `cursor.sh` now registers `beforeShellExecution`, `preToolUse`, `beforeMCPExecution`, and `subagentStart` (was only 2).
+- **Cursor hook unit tests.** 15 test cases covering all hook event types, including fail-closed for unknown tools and fail-open for empty stdin.
+
+### Changed
+- **Test fixture:** `passport.oap-v1.json` expanded from 3 to 9 capabilities with matching limits.
+- Read-family tools (`Read`, `Grep`) exit 0 without calling evaluator in Cursor hook (matches Claude Code behavior).
+- Unknown `preToolUse` tools are denied (fail-closed) in Cursor hook.
+
+### Security
+- Per-invocation decision files in Cursor hook (PID-suffixed) prevent race conditions with concurrent tool calls.
+- Fail-closed design: unrecognized hook input shapes are denied by default.
+
 ## [1.0.13] - 2026-03-11
 
 ### Added

--- a/bin/aport-create-passport.sh
+++ b/bin/aport-create-passport.sh
@@ -109,6 +109,64 @@ DEFAULT_AGENT_NAME=${DEFAULT_AGENT_NAME:-"OpenClaw Agent"}
 DEFAULT_AGENT_DESC=$(get_identity_description) || true
 DEFAULT_AGENT_DESC=${DEFAULT_AGENT_DESC:-"Local OpenClaw AI agent with APort guardrails"}
 
+# Framework-aware defaults: each framework needs different capabilities to function
+case "${APORT_FRAMEWORK:-}" in
+    claude-code)
+        # Claude Code: file ops, web, sub-agents, MCP tools are core functionality
+        DEFAULT_FILE_READ=y
+        DEFAULT_FILE_WRITE=y
+        DEFAULT_WEB_FETCH=y
+        DEFAULT_WEB_BROWSER=y
+        DEFAULT_AGENT_SESSION=y
+        DEFAULT_MCP_TOOL=y
+        ;;
+    cursor)
+        # Cursor: IDE with shell, file ops, web search, agent mode
+        DEFAULT_FILE_READ=y
+        DEFAULT_FILE_WRITE=y
+        DEFAULT_WEB_FETCH=y
+        DEFAULT_WEB_BROWSER=n
+        DEFAULT_AGENT_SESSION=y
+        DEFAULT_MCP_TOOL=n
+        ;;
+    crewai)
+        # CrewAI: multi-agent framework — agents spawn sub-agents, use tools
+        DEFAULT_FILE_READ=y
+        DEFAULT_FILE_WRITE=y
+        DEFAULT_WEB_FETCH=y
+        DEFAULT_WEB_BROWSER=n
+        DEFAULT_AGENT_SESSION=y
+        DEFAULT_MCP_TOOL=y
+        ;;
+    langchain)
+        # LangChain/LangGraph: tool calling, web, files
+        DEFAULT_FILE_READ=y
+        DEFAULT_FILE_WRITE=y
+        DEFAULT_WEB_FETCH=y
+        DEFAULT_WEB_BROWSER=n
+        DEFAULT_AGENT_SESSION=n
+        DEFAULT_MCP_TOOL=n
+        ;;
+    n8n)
+        # n8n: workflow automation — HTTP, file, database, messaging
+        DEFAULT_FILE_READ=y
+        DEFAULT_FILE_WRITE=y
+        DEFAULT_WEB_FETCH=y
+        DEFAULT_WEB_BROWSER=n
+        DEFAULT_AGENT_SESSION=n
+        DEFAULT_MCP_TOOL=n
+        ;;
+    *)
+        # Generic / unknown framework: conservative defaults
+        DEFAULT_FILE_READ=n
+        DEFAULT_FILE_WRITE=n
+        DEFAULT_WEB_FETCH=n
+        DEFAULT_WEB_BROWSER=n
+        DEFAULT_AGENT_SESSION=n
+        DEFAULT_MCP_TOOL=n
+        ;;
+esac
+
 if [ -n "$NON_INTERACTIVE" ]; then
     # CI/tests: use defaults, no prompts. Use --output or APORT_FRAMEWORK for default path. Match interactive defaults (README: messaging out of the box).
     owner_id="$DEFAULT_EMAIL"
@@ -119,10 +177,12 @@ if [ -n "$NON_INTERACTIVE" ]; then
     exec_cap=y
     msg_cap=y
     data_cap=n
-    file_read_cap=n
-    file_write_cap=n
-    web_fetch_cap=n
-    web_browser_cap=n
+    file_read_cap=$DEFAULT_FILE_READ
+    file_write_cap=$DEFAULT_FILE_WRITE
+    web_fetch_cap=$DEFAULT_WEB_FETCH
+    web_browser_cap=$DEFAULT_WEB_BROWSER
+    agent_session_cap=$DEFAULT_AGENT_SESSION
+    mcp_tool_cap=$DEFAULT_MCP_TOOL
     max_pr_size=500
     max_prs_per_day=10
     max_msgs_per_day=100
@@ -195,7 +255,11 @@ else
     # Choose capabilities
     echo "  🔐 Capabilities"
     echo "  ───────────────"
-    echo "  Choose what your agent can do (y/n). Defaults: PRs, exec, and messaging = yes (matches README/docs); others = no."
+    if [ "${APORT_FRAMEWORK:-}" = "claude-code" ]; then
+        echo "  Choose what your agent can do (y/n). Claude Code defaults: most capabilities = yes."
+    else
+        echo "  Choose what your agent can do (y/n). Defaults: PRs, exec, and messaging = yes (matches README/docs); others = no."
+    fi
     echo ""
     read -p "  • Create and merge pull requests? [Y/n]: " pr_cap
     pr_cap=${pr_cap:-y}
@@ -206,20 +270,50 @@ else
     read -p "  • Send messages (email, SMS, etc.)? [Y/n]: " msg_cap
     msg_cap=${msg_cap:-y}
 
-    read -p "  • Read files from disk? [y/N]: " file_read_cap
-    file_read_cap=${file_read_cap:-n}
+    if [ "$DEFAULT_FILE_READ" = "y" ]; then
+        read -p "  • Read files from disk? [Y/n]: " file_read_cap
+    else
+        read -p "  • Read files from disk? [y/N]: " file_read_cap
+    fi
+    file_read_cap=${file_read_cap:-$DEFAULT_FILE_READ}
 
-    read -p "  • Write/edit files on disk? [y/N]: " file_write_cap
-    file_write_cap=${file_write_cap:-n}
+    if [ "$DEFAULT_FILE_WRITE" = "y" ]; then
+        read -p "  • Write/edit files on disk? [Y/n]: " file_write_cap
+    else
+        read -p "  • Write/edit files on disk? [y/N]: " file_write_cap
+    fi
+    file_write_cap=${file_write_cap:-$DEFAULT_FILE_WRITE}
 
-    read -p "  • Fetch data from web (HTTP requests)? [y/N]: " web_fetch_cap
-    web_fetch_cap=${web_fetch_cap:-n}
+    if [ "$DEFAULT_WEB_FETCH" = "y" ]; then
+        read -p "  • Fetch data from web (HTTP requests)? [Y/n]: " web_fetch_cap
+    else
+        read -p "  • Fetch data from web (HTTP requests)? [y/N]: " web_fetch_cap
+    fi
+    web_fetch_cap=${web_fetch_cap:-$DEFAULT_WEB_FETCH}
 
-    read -p "  • Automate web browser? [y/N]: " web_browser_cap
-    web_browser_cap=${web_browser_cap:-n}
+    if [ "$DEFAULT_WEB_BROWSER" = "y" ]; then
+        read -p "  • Automate web browser? [Y/n]: " web_browser_cap
+    else
+        read -p "  • Automate web browser? [y/N]: " web_browser_cap
+    fi
+    web_browser_cap=${web_browser_cap:-$DEFAULT_WEB_BROWSER}
 
     read -p "  • Export data (database, files, etc.)? [y/N]: " data_cap
     data_cap=${data_cap:-n}
+
+    if [ "$DEFAULT_AGENT_SESSION" = "y" ]; then
+        read -p "  • Spawn sub-agents and tasks? [Y/n]: " agent_session_cap
+    else
+        read -p "  • Spawn sub-agents and tasks? [y/N]: " agent_session_cap
+    fi
+    agent_session_cap=${agent_session_cap:-$DEFAULT_AGENT_SESSION}
+
+    if [ "$DEFAULT_MCP_TOOL" = "y" ]; then
+        read -p "  • Use MCP tools (external integrations)? [Y/n]: " mcp_tool_cap
+    else
+        read -p "  • Use MCP tools (external integrations)? [y/N]: " mcp_tool_cap
+    fi
+    mcp_tool_cap=${mcp_tool_cap:-$DEFAULT_MCP_TOOL}
 
     echo ""
 
@@ -351,6 +445,12 @@ fi
 if [ "$data_cap" = "y" ] || [ "$data_cap" = "Y" ]; then
     capabilities_json="$capabilities_json{\"id\": \"data.export\"},"
 fi
+if [ "${agent_session_cap:-n}" = "y" ] || [ "${agent_session_cap:-n}" = "Y" ]; then
+    capabilities_json="$capabilities_json{\"id\": \"agent.session.create\"},"
+fi
+if [ "${mcp_tool_cap:-n}" = "y" ] || [ "${mcp_tool_cap:-n}" = "Y" ]; then
+    capabilities_json="$capabilities_json{\"id\": \"mcp.tool.execute\"},"
+fi
 # Remove trailing comma
 capabilities_json="${capabilities_json%,}]"
 
@@ -436,6 +536,14 @@ fi
 
 if [ "$data_cap" = "y" ] || [ "$data_cap" = "Y" ]; then
     limits_json="$limits_json\"data.export\": {\"max_rows\": $max_export_rows, \"allow_pii\": $allow_pii_bool, \"allowed_collections\": [\"*\"]},"
+fi
+
+if [ "${agent_session_cap:-n}" = "y" ] || [ "${agent_session_cap:-n}" = "Y" ]; then
+    limits_json="$limits_json\"agent.session.create\": {\"max_concurrent\": 10},"
+fi
+
+if [ "${mcp_tool_cap:-n}" = "y" ] || [ "${mcp_tool_cap:-n}" = "Y" ]; then
+    limits_json="$limits_json\"mcp.tool.execute\": {\"allowed_servers\": [\"*\"]},"
 fi
 
 # Remove trailing comma
@@ -540,7 +648,13 @@ echo "  🔐 Capabilities:"
 [ "$pr_cap" = "y" ] || [ "$pr_cap" = "Y" ] && echo "    • Create and merge pull requests"
 [ "$exec_cap" = "y" ] || [ "$exec_cap" = "Y" ] && echo "    • Execute system commands"
 [ "$msg_cap" = "y" ] || [ "$msg_cap" = "Y" ] && echo "    • Send messages"
+[ "$file_read_cap" = "y" ] || [ "$file_read_cap" = "Y" ] && echo "    • Read files"
+[ "$file_write_cap" = "y" ] || [ "$file_write_cap" = "Y" ] && echo "    • Write/edit files"
+[ "$web_fetch_cap" = "y" ] || [ "$web_fetch_cap" = "Y" ] && echo "    • Fetch from web"
+[ "$web_browser_cap" = "y" ] || [ "$web_browser_cap" = "Y" ] && echo "    • Automate browser"
 [ "$data_cap" = "y" ] || [ "$data_cap" = "Y" ] && echo "    • Export data"
+[ "${agent_session_cap:-n}" = "y" ] || [ "${agent_session_cap:-n}" = "Y" ] && echo "    • Spawn sub-agents and tasks"
+[ "${mcp_tool_cap:-n}" = "y" ] || [ "${mcp_tool_cap:-n}" = "Y" ] && echo "    • Use MCP tools"
 echo ""
 echo "  📝 Next steps:"
 echo "    • Review limits:  vim $PASSPORT_FILE"

--- a/bin/aport-cursor-hook.sh
+++ b/bin/aport-cursor-hook.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# APort Cursor/Copilot/Claude Code hook: read JSON from stdin, call guardrail, return allow/deny; exit 2 = block.
-# Compatible with Cursor (beforeShellExecution, preToolUse), VS Code Copilot, and Claude Code.
-# Input: JSON with "command" and/or "tool"/"name"/"input" (host-dependent). We map to system.command.execute.
-# Output: JSON with "permission": "allow"|"deny" (Cursor) and "allowed": true|false; optional "agentMessage"/"reason".
-# Exit: 0 = allow, 2 = block (deny). Other exits = hook error (host may proceed or fail-open).
+# APort Cursor hook: reads JSON from stdin, maps tool to APort policy, calls guardrail.
+# Handles all Cursor hook events: beforeShellExecution, preToolUse, beforeMCPExecution,
+# beforeReadFile, subagentStart.
+# Output: JSON with "permission": "allow"|"deny"; optional "agentMessage"/"user_message".
+# Exit: 0 = allow, 2 = block (deny). Other exits = hook error (Cursor may fail-open).
+#
+# Cursor preToolUse tool_name values: Shell, Read, Write, Grep, Delete, Task, MCP:<name>
+# See: https://cursor.com/docs/hooks
 
 set -e
 
@@ -11,14 +14,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 GUARDRAIL="$ROOT_DIR/bin/aport-guardrail-bash.sh"
 
-# Passport/config: resolver probes ~/.cursor, ~/.openclaw, ~/.aport/langchain, etc. when OPENCLAW_CONFIG_DIR not set
+# Passport/config: resolver probes ~/.cursor, ~/.openclaw, ~/.aport/*, etc.
 # shellcheck source=bin/aport-resolve-paths.sh
 . "$ROOT_DIR/bin/aport-resolve-paths.sh"
 
 # Read stdin (single JSON object; Cursor sends one payload per invocation)
 INPUT=""
 if [ -t 0 ]; then
-    # No stdin (e.g. manual test): treat as allow to avoid blocking
     INPUT='{}'
 else
     INPUT="$(cat)"
@@ -30,61 +32,145 @@ if [ -z "$INPUT" ]; then
     exit 0
 fi
 
-# Parse and normalize to tool + context for guardrail
-# Cursor beforeShellExecution: { "command": "..." }
-# preToolUse / Copilot: { "tool": "runTerminalCommand", "input": { "command": "..." } } or similar
-TOOL_NAME="exec.run"
-CONTEXT_JSON="{}"
-if command -v jq &> /dev/null; then
-    CMD=$(echo "$INPUT" | jq -r '.command // .input.command // .input.cmd // .args[0] // ""')
-    if [ -n "$CMD" ] && [ "$CMD" != "null" ]; then
-        CONTEXT_JSON=$(echo "$INPUT" | jq -c '{command: (.command // .input.command // .input.cmd), args: (.args // .input.args // [])}' 2> /dev/null || echo "{}")
-        if [ -z "$CONTEXT_JSON" ] || [ "$CONTEXT_JSON" = "null" ]; then
-            CONTEXT_JSON=$(jq -n -c --arg cmd "$CMD" '{command: $cmd}')
-        fi
-    fi
-    # If no command found, still pass through; guardrail may deny unknown
-    if [ -z "$CONTEXT_JSON" ] || [ "$CONTEXT_JSON" = "null" ]; then
-        CONTEXT_JSON="$INPUT"
-    fi
-else
-    CONTEXT_JSON="$INPUT"
+# Require jq for JSON parsing
+if ! command -v jq &> /dev/null; then
+    echo '{"permission":"deny","allowed":false,"agentMessage":"APort: jq is required"}'
+    exit 2
 fi
 
-# Call existing bash guardrail: exit 0 = allow, exit 1 = deny (forward config for subprocess)
+# Deny helper: outputs Cursor-format JSON and exits 2
+deny() {
+    local reason="$1"
+    jq -n -c --arg reason "$reason" \
+        '{permission:"deny",allowed:false,agentMessage:$reason,reason:$reason}'
+    exit 2
+}
+
+# Safe jq extraction: returns '{}' on any jq error
+safe_jq() {
+    local input="$1" filter="$2"
+    local result
+    result="$(echo "$input" | jq -c "$filter" 2> /dev/null)" || result='{}'
+    [ -z "$result" ] && result='{}'
+    echo "$result"
+}
+
+# Detect hook event type from input fields and route accordingly.
+# Cursor sends different JSON shapes per hook event:
+#   beforeShellExecution: { "command": "...", "cwd": "..." }
+#   preToolUse:           { "tool_name": "Shell|Read|Write|...", "tool_input": {...} }
+#   beforeMCPExecution:   { "tool_name": "...", "tool_input": {...}, "server": "..." }
+#   beforeReadFile:       { "file_path": "...", "content": "..." }
+#   subagentStart:        { "subagent_id": "...", "subagent_type": "...", "task": "..." }
+# We detect by checking for distinguishing fields.
+
+GUARDRAIL_TOOL=""
+CONTEXT_JSON="{}"
+
+# Check for hook_event_name first (newer Cursor versions include it)
+HOOK_EVENT="$(echo "$INPUT" | jq -r '.hook_event_name // ""' 2> /dev/null)"
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""' 2> /dev/null)"
+
+if [ "$HOOK_EVENT" = "beforeReadFile" ] || { [ -z "$HOOK_EVENT" ] && [ -z "$TOOL_NAME" ] && echo "$INPUT" | jq -e '.file_path and .content' &> /dev/null; }; then
+    # beforeReadFile: file reads — allow without evaluator (same as Claude Code)
+    exit 0
+
+elif [ "$HOOK_EVENT" = "subagentStart" ] || { [ -z "$HOOK_EVENT" ] && echo "$INPUT" | jq -e '.subagent_id' &> /dev/null; }; then
+    # subagentStart: sub-agent spawning
+    GUARDRAIL_TOOL="session.create"
+    CONTEXT_JSON="$(safe_jq "$INPUT" '{description: (.task // ""), subagent_type: (.subagent_type // "")}')"
+
+elif [ "$HOOK_EVENT" = "beforeMCPExecution" ] || { [ -n "$TOOL_NAME" ] && echo "$INPUT" | jq -e '.server // .url' &> /dev/null; }; then
+    # beforeMCPExecution: MCP tool calls (has server/url field)
+    GUARDRAIL_TOOL="mcp.tool"
+    CONTEXT_JSON="$(safe_jq "$INPUT" '{tool_name: (.tool_name // ""), tool_input: (.tool_input // {})}')"
+
+elif [ -n "$TOOL_NAME" ]; then
+    # preToolUse: Cursor tool names — Shell, Read, Write, Grep, Delete, Task, MCP:<name>
+    case "$TOOL_NAME" in
+        Shell)
+            GUARDRAIL_TOOL="bash"
+            CONTEXT_JSON="$(safe_jq "$INPUT" '{command: (.tool_input.command // "")}')"
+            ;;
+        Read | Grep)
+            # Read-family: allow without calling evaluator
+            exit 0
+            ;;
+        Write)
+            GUARDRAIL_TOOL="write"
+            CONTEXT_JSON="$(safe_jq "$INPUT" '{file_path: (.tool_input.file_path // .tool_input.path // "")}')"
+            ;;
+        Delete)
+            GUARDRAIL_TOOL="write"
+            CONTEXT_JSON="$(safe_jq "$INPUT" '{file_path: (.tool_input.file_path // .tool_input.path // "")}')"
+            ;;
+        Task)
+            GUARDRAIL_TOOL="session.create"
+            CONTEXT_JSON="$(safe_jq "$INPUT" '{description: (.tool_input.description // .tool_input.prompt // "")}')"
+            ;;
+        MCP:*)
+            GUARDRAIL_TOOL="mcp.tool"
+            CONTEXT_JSON="$(safe_jq "$INPUT" '{tool_name: (.tool_name // ""), tool_input: (.tool_input // {})}')"
+            ;;
+        *)
+            # Unknown preToolUse tool: fail-closed
+            deny "🛡️ APort: unknown tool '$TOOL_NAME' — fail-closed policy"
+            ;;
+    esac
+
+elif echo "$INPUT" | jq -e '.command' &> /dev/null; then
+    # beforeShellExecution: { "command": "..." }
+    GUARDRAIL_TOOL="bash"
+    CMD="$(echo "$INPUT" | jq -r '.command // ""' 2> /dev/null)"
+    CONTEXT_JSON="$(jq -n -c --arg cmd "$CMD" '{command: $cmd}')"
+
+elif echo "$INPUT" | jq -e '.tool // .input.command' &> /dev/null; then
+    # Legacy Copilot-style: { "tool": "runTerminalCommand", "input": { "command": "..." } }
+    GUARDRAIL_TOOL="bash"
+    CMD="$(echo "$INPUT" | jq -r '.input.command // .input.cmd // .args[0] // ""' 2> /dev/null)"
+    CONTEXT_JSON="$(jq -n -c --arg cmd "$CMD" '{command: $cmd}')"
+
+else
+    # Unrecognized input shape: fail-closed
+    deny "🛡️ APort: unrecognized hook input — fail-closed policy"
+fi
+
+# Use a per-invocation decision file to avoid race conditions with concurrent tool calls
+HOOK_DECISION_FILE="${OPENCLAW_DECISION_FILE:-}"
+if [ -n "$HOOK_DECISION_FILE" ]; then
+    HOOK_DECISION_FILE="${HOOK_DECISION_FILE%.json}-$$.json"
+    export OPENCLAW_DECISION_FILE="$HOOK_DECISION_FILE"
+fi
+
+# Call core evaluator
 set +e
-OPENCLAW_CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}" OPENCLAW_PASSPORT_FILE="${OPENCLAW_PASSPORT_FILE:-}" OPENCLAW_DECISION_FILE="${OPENCLAW_DECISION_FILE:-}" "$GUARDRAIL" "$TOOL_NAME" "$CONTEXT_JSON" 2> /dev/null
+"$GUARDRAIL" "$GUARDRAIL_TOOL" "$CONTEXT_JSON" 2> /dev/null
 GUARDRAIL_EXIT=$?
 set -e
 
+# Clean up per-invocation decision file
+cleanup_decision() { [ -n "$HOOK_DECISION_FILE" ] && rm -f "$HOOK_DECISION_FILE" 2> /dev/null; }
+
 if [ "$GUARDRAIL_EXIT" -eq 0 ]; then
+    cleanup_decision
     echo '{"permission":"allow","allowed":true}'
     exit 0
 fi
 
-# Deny: output reason from decision file if available (guardrail writes decision before exit 1)
+# Deny: read reason from decision file
 REASON="Policy denied this action."
-if [ -n "${OPENCLAW_DECISION_FILE:-}" ] && [ -f "$OPENCLAW_DECISION_FILE" ] && command -v jq &> /dev/null; then
-    R=$(jq -r '.reasons[0].message // empty' "$OPENCLAW_DECISION_FILE" 2> /dev/null)
-    if [ -n "$R" ]; then
-        REASON="$R"
-    fi
+if [ -n "$HOOK_DECISION_FILE" ] && [ -f "$HOOK_DECISION_FILE" ]; then
+    R="$(jq -r '.reasons[0].message // empty' "$HOOK_DECISION_FILE" 2> /dev/null)"
+    [ -n "$R" ] && REASON="$R"
 fi
-# If no decision file was set, try common config dirs so we can show actual deny reason
-if [ "$REASON" = "Policy denied this action." ] && command -v jq &> /dev/null; then
+# Fallback: try common config dirs
+if [ "$REASON" = "Policy denied this action." ]; then
     for DEC in "${OPENCLAW_CONFIG_DIR:-$HOME/.cursor}/aport/decision.json" "$HOME/.cursor/aport/decision.json" "$HOME/.openclaw/aport/decision.json"; do
         if [ -f "$DEC" ]; then
-            R=$(jq -r '.reasons[0].message // empty' "$DEC" 2> /dev/null)
-            if [ -n "$R" ]; then
-                REASON="$R"
-                break
-            fi
+            R="$(jq -r '.reasons[0].message // empty' "$DEC" 2> /dev/null)"
+            [ -n "$R" ] && REASON="$R" && break
         fi
     done
 fi
-# Fallback: help user debug guardrail/script errors
-if [ "$REASON" = "Policy denied this action." ]; then
-    REASON="Policy denied or guardrail error. Check passport and guardrail script (see docs/frameworks/cursor.md)."
-fi
-echo "{\"permission\":\"deny\",\"allowed\":false,\"agentMessage\":$(echo "$REASON" | jq -Rs .),\"reason\":$(echo "$REASON" | jq -Rs .)}"
-exit 2
+cleanup_decision
+deny "🛡️ APort: $REASON"

--- a/bin/frameworks/cursor.sh
+++ b/bin/frameworks/cursor.sh
@@ -45,12 +45,13 @@ run_setup() {
     if [ -f "$CURSOR_HOOKS_FILE" ] && command -v jq &> /dev/null; then
         EXISTING=$(cat "$CURSOR_HOOKS_FILE")
         if echo "$EXISTING" | jq -e '.hooks' &> /dev/null; then
-            # Add APort hook to beforeShellExecution and preToolUse (avoid duplicate)
+            # Add APort hook to all supported lifecycle events (avoid duplicate)
             NEW_HOOKS=$(echo "$EXISTING" | jq -c --arg cmd "$HOOK_SCRIPT" '
-        (.hooks.beforeShellExecution // []) as $b |
-        (.hooks.preToolUse // []) as $p |
-        .hooks.beforeShellExecution = ($b | map(select(.command != $cmd)) | . + [{ "command": $cmd }]) |
-        .hooks.preToolUse = ($p | map(select(.command != $cmd)) | . + [{ "command": $cmd }])
+        def upsert_hook: map(select(.command != $cmd)) | . + [{ "command": $cmd }];
+        .hooks.beforeShellExecution = ((.hooks.beforeShellExecution // []) | upsert_hook) |
+        .hooks.preToolUse = ((.hooks.preToolUse // []) | upsert_hook) |
+        .hooks.beforeMCPExecution = ((.hooks.beforeMCPExecution // []) | upsert_hook) |
+        .hooks.subagentStart = ((.hooks.subagentStart // []) | upsert_hook)
       ')
             [ -f "$CURSOR_HOOKS_FILE" ] && cp "$CURSOR_HOOKS_FILE" "${CURSOR_HOOKS_FILE}.bak"
             echo "$NEW_HOOKS" > "$CURSOR_HOOKS_FILE"
@@ -82,7 +83,9 @@ _write_cursor_hooks_file() {
       version: 1,
       hooks: {
         beforeShellExecution: [{ command: $cmd }],
-        preToolUse: [{ command: $cmd }]
+        preToolUse: [{ command: $cmd }],
+        beforeMCPExecution: [{ command: $cmd }],
+        subagentStart: [{ command: $cmd }]
       }
     }' > "$file"
     else
@@ -93,7 +96,9 @@ _write_cursor_hooks_file() {
   "version": 1,
   "hooks": {
     "beforeShellExecution": [{"command": "${escaped_cmd}"}],
-    "preToolUse": [{"command": "${escaped_cmd}"}]
+    "preToolUse": [{"command": "${escaped_cmd}"}],
+    "beforeMCPExecution": [{"command": "${escaped_cmd}"}],
+    "subagentStart": [{"command": "${escaped_cmd}"}]
   }
 }
 EOF

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release process and version policy
 
-**Current release:** 1.0.13 (see [CHANGELOG.md](../CHANGELOG.md)).
+**Current release:** 1.0.14 (see [CHANGELOG.md](../CHANGELOG.md)).
 
 We keep **one version number** across all published packages (Node core, Python core, and every framework adapter). That avoids “core is 1.2 but CLI is 0.9” and keeps the story simple for users and support.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -15760,7 +15760,7 @@
     },
     "packages/claude-code": {
       "name": "@aporthq/aport-agent-guardrails-claude-code",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.13"
@@ -15772,7 +15772,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -15791,7 +15791,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.13"
@@ -15803,7 +15803,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.13"
@@ -15815,7 +15815,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15832,7 +15832,7 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.13",
@@ -15848,7 +15848,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "workspaces": [
     "packages/*",

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-claude-code",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "APort guardrails for Claude Code — PreToolUse hook",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
   "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
   "main": "index.js",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/python/aport_guardrails/__init__.py
+++ b/python/aport_guardrails/__init__.py
@@ -3,7 +3,7 @@ aport_guardrails — Core evaluator, passport, and config for APort agent guardr
 Shared across Python framework adapters (LangChain, CrewAI, AutoGen).
 """
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 
 from aport_guardrails.core.evaluator import Evaluator, Decision, ToolContext
 from aport_guardrails.core.passport import load_passport, validate_passport

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.13"
+version = "1.0.14"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.13"
+version = "1.0.14"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.13"
+version = "1.0.14"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/fixtures/passport.oap-v1.json
+++ b/tests/fixtures/passport.oap-v1.json
@@ -9,7 +9,13 @@
   "capabilities": [
     {"id": "repo.pr.create"},
     {"id": "repo.merge"},
-    {"id": "system.command.execute"}
+    {"id": "system.command.execute"},
+    {"id": "data.file.read"},
+    {"id": "data.file.write"},
+    {"id": "web.fetch"},
+    {"id": "web.browser"},
+    {"id": "agent.session.create"},
+    {"id": "mcp.tool.execute"}
   ],
   "limits": {
     "code.repository.merge": {
@@ -23,6 +29,29 @@
     "system.command.execute": {
       "allowed_commands": ["mkdir", "ls", "bash", "npm", "git", "node", "pnpm"],
       "blocked_patterns": ["rm -rf", "sudo"]
+    },
+    "data.file.read": {
+      "allowed_paths": ["*"],
+      "max_file_size_mb": 100
+    },
+    "data.file.write": {
+      "allowed_paths": ["*"],
+      "max_file_size_mb": 50
+    },
+    "web.fetch": {
+      "allowed_domains": ["*"],
+      "blocked_domains": [],
+      "max_requests_per_min": 60
+    },
+    "web.browser": {
+      "allowed_domains": ["*"],
+      "max_screenshots_per_hour": 100
+    },
+    "agent.session.create": {
+      "max_concurrent": 10
+    },
+    "mcp.tool.execute": {
+      "allowed_servers": ["*"]
     }
   },
   "regions": ["US", "CA"],

--- a/tests/unit/test-cursor-hook.sh
+++ b/tests/unit/test-cursor-hook.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Unit tests for Cursor hook script: mock stdin (allow/deny), assert exit 0/2 and output JSON.
+# Unit tests for Cursor hook script: tests all hook event types (beforeShellExecution,
+# preToolUse with Shell/Read/Write/Delete/Task/MCP, beforeMCPExecution, subagentStart).
 # Uses test passport and guardrail; hook reads stdin and calls guardrail.
 
 set -e
@@ -18,81 +19,86 @@ HOOK_SCRIPT="$REPO_ROOT/bin/aport-cursor-hook.sh"
 chmod +x "$HOOK_SCRIPT" 2> /dev/null || true
 
 echo ""
-echo "  Unit — Cursor hook script (allow/deny, exit 0/2)"
+echo "  Unit — Cursor hook script (all hook events)"
 echo "  Hook: $HOOK_SCRIPT"
 echo ""
 
-# 1. Allow: command in allowlist (e.g. ls) -> exit 0, allowed: true
-echo "  Test: stdin allow (command allowed by passport)..."
-OUT1="$TEST_DIR/hook-allow-out.txt"
-echo '{"command":"ls -la"}' | OPENCLAW_CONFIG_DIR="$TEST_DIR" "$HOOK_SCRIPT" > "$OUT1" 2> /dev/null
-EXIT1=$?
-[[ "$EXIT1" -eq 0 ]] || {
-    echo "FAIL: expected exit 0 for allow, got $EXIT1" >&2
-    exit 1
+# Helper: run hook with input, check exit code and output
+run_hook() {
+    local desc="$1" input="$2" expect_exit="$3" expect_field="$4"
+    local out="$TEST_DIR/hook-out-$RANDOM.txt"
+    set +e
+    echo "$input" | OPENCLAW_CONFIG_DIR="$TEST_DIR" "$HOOK_SCRIPT" > "$out" 2> /dev/null
+    local actual_exit=$?
+    set -e
+    if [[ "$actual_exit" -ne "$expect_exit" ]]; then
+        echo "FAIL: $desc — expected exit $expect_exit, got $actual_exit (output: $(cat "$out"))" >&2
+        exit 1
+    fi
+    if [ -n "$expect_field" ] && ! grep -q "$expect_field" "$out"; then
+        echo "FAIL: $desc — expected '$expect_field' in output: $(cat "$out")" >&2
+        exit 1
+    fi
+    echo "  ✅ $desc"
 }
-grep -q '"allowed":true' "$OUT1" || {
-    echo "FAIL: output should contain allowed:true" >&2
-    cat "$OUT1" >&2
-    exit 1
-}
-grep -q '"permission":"allow"' "$OUT1" || {
-    echo "FAIL: output should contain permission:allow" >&2
-    exit 1
-}
-echo "  ✅ Allow: exit 0, permission allow, allowed true"
 
-# 2. Deny: blocked pattern (e.g. rm -rf) -> exit 2, allowed: false
-echo "  Test: stdin deny (blocked pattern)..."
-OUT2="$TEST_DIR/hook-deny-out.txt"
-set +e
-echo '{"command":"rm -rf /tmp/x"}' | OPENCLAW_CONFIG_DIR="$TEST_DIR" OPENCLAW_PASSPORT_FILE="$TEST_DIR/aport/passport.json" "$HOOK_SCRIPT" > "$OUT2" 2> /dev/null
-EXIT2=$?
-set -e
-[[ "$EXIT2" -eq 2 ]] || {
-    echo "FAIL: expected exit 2 for deny, got $EXIT2 (output: $(cat "$OUT2"))" >&2
-    exit 1
-}
-grep -q '"allowed":false' "$OUT2" || {
-    echo "FAIL: output should contain allowed:false" >&2
-    cat "$OUT2" >&2
-    exit 1
-}
-grep -q '"permission":"deny"' "$OUT2" || {
-    echo "FAIL: output should contain permission:deny" >&2
-    exit 1
-}
-echo "  ✅ Deny: exit 2, permission deny, allowed false"
+# --- beforeShellExecution ---
+run_hook "beforeShellExecution: allow (ls)" \
+    '{"command":"ls -la"}' 0 '"permission":"allow"'
 
-# 3. Copilot-style input: input.command
-echo "  Test: Copilot-style JSON (input.command)..."
-OUT3="$TEST_DIR/hook-copilot-out.txt"
-echo '{"tool":"runTerminalCommand","input":{"command":"npm install"}}' | OPENCLAW_CONFIG_DIR="$TEST_DIR" "$HOOK_SCRIPT" > "$OUT3" 2> /dev/null
-EXIT3=$?
-[[ "$EXIT3" -eq 0 ]] || {
-    echo "FAIL: expected exit 0 for npm install, got $EXIT3" >&2
-    exit 1
-}
-grep -q '"allowed":true' "$OUT3" || {
-    echo "FAIL: Copilot-style allow" >&2
-    exit 1
-}
-echo "  ✅ Copilot-style input -> allow"
+run_hook "beforeShellExecution: deny (rm -rf)" \
+    '{"command":"rm -rf /tmp/x"}' 2 '"permission":"deny"'
 
-# 4. Empty stdin -> fail-open allow (per script)
-echo "  Test: empty stdin -> allow with message..."
-OUT4="$TEST_DIR/hook-empty-out.txt"
-printf '' | OPENCLAW_CONFIG_DIR="$TEST_DIR" "$HOOK_SCRIPT" > "$OUT4" 2> /dev/null
-EXIT4=$?
-[[ "$EXIT4" -eq 0 ]] || {
-    echo "FAIL: empty stdin should exit 0 (fail-open)" >&2
-    exit 1
-}
-grep -q '"allowed":true' "$OUT4" || {
-    echo "FAIL: empty stdin allow" >&2
-    exit 1
-}
-echo "  ✅ Empty stdin -> allow (fail-open)"
+# --- preToolUse: Shell ---
+run_hook "preToolUse Shell: allow (ls)" \
+    '{"tool_name":"Shell","tool_input":{"command":"ls -la"}}' 0 '"permission":"allow"'
+
+run_hook "preToolUse Shell: deny (sudo)" \
+    '{"tool_name":"Shell","tool_input":{"command":"sudo reboot"}}' 2 '"permission":"deny"'
+
+# --- preToolUse: Read (allow without evaluator) ---
+run_hook "preToolUse Read: allow (no evaluator)" \
+    '{"tool_name":"Read","tool_input":{"file_path":"/tmp/test.txt"}}' 0 ''
+
+# --- preToolUse: Grep (allow without evaluator) ---
+run_hook "preToolUse Grep: allow (no evaluator)" \
+    '{"tool_name":"Grep","tool_input":{"pattern":"TODO"}}' 0 ''
+
+# --- preToolUse: Write ---
+run_hook "preToolUse Write: allow" \
+    '{"tool_name":"Write","tool_input":{"file_path":"/tmp/test.txt"}}' 0 '"permission":"allow"'
+
+# --- preToolUse: Delete ---
+run_hook "preToolUse Delete: allow" \
+    '{"tool_name":"Delete","tool_input":{"file_path":"/tmp/test.txt"}}' 0 '"permission":"allow"'
+
+# --- preToolUse: Task ---
+run_hook "preToolUse Task: allow" \
+    '{"tool_name":"Task","tool_input":{"description":"run tests"}}' 0 '"permission":"allow"'
+
+# --- preToolUse: MCP:<name> ---
+run_hook "preToolUse MCP:tool: allow" \
+    '{"tool_name":"MCP:github_search","tool_input":{"query":"test"}}' 0 '"permission":"allow"'
+
+# --- preToolUse: unknown tool (fail-closed) ---
+run_hook "preToolUse unknown: deny (fail-closed)" \
+    '{"tool_name":"SomethingNew","tool_input":{}}' 2 '"permission":"deny"'
+
+# --- beforeMCPExecution ---
+run_hook "beforeMCPExecution: allow" \
+    '{"tool_name":"github_search","tool_input":{"query":"test"},"server":"github","url":"http://localhost:3000"}' 0 '"permission":"allow"'
+
+# --- subagentStart ---
+run_hook "subagentStart: allow" \
+    '{"subagent_id":"abc-123","subagent_type":"worker","task":"run unit tests"}' 0 '"permission":"allow"'
+
+# --- Legacy Copilot-style ---
+run_hook "Copilot-style: allow (npm install)" \
+    '{"tool":"runTerminalCommand","input":{"command":"npm install"}}' 0 '"permission":"allow"'
+
+# --- Empty stdin -> fail-open ---
+run_hook "Empty stdin: allow (fail-open)" \
+    '' 0 '"allowed":true'
 
 echo ""
 echo "  All Cursor hook unit tests passed."


### PR DESCRIPTION
Adds agent.session.create and mcp.tool.execute capabilities to the passport wizard. Claude Code needs these to spawn sub-agents (Agent, Task, Skill) and use MCP tools. Without them, APort blocks normal usage.

Defaults are now framework-aware: claude-code sets file read/write, web fetch, browser, agent session, and MCP tool capabilities to yes. Other frameworks keep existing defaults (no regression).
