### PR TITLE
feat(openclaw-aport): add aport_check and aport_passport optional agent tools

### DIFF
--- a/.changeset/feat-openclaw-agent-tools.md
+++ b/.changeset/feat-openclaw-agent-tools.md
@@ -1,0 +1,12 @@
+---
+"@aporthq/openclaw-aport": minor
+---
+
+feat(openclaw-aport): add aport_check and aport_passport optional agent tools
+
+Adds two optional, opt-in tools to the OpenClaw plugin:
+- `aport_check`: lets the agent query whether a tool call is authorized before executing it
+- `aport_passport`: lets the agent inspect or scaffold its APort passport
+
+Both tools are registered with `optional: true` and require explicit opt-in via `agents.list[].tools.allow`.
+All logic reuses existing helpers (mapToolToPolicy, verifyViaScript/API, verifyDecisionIntegrity). No behavioral changes to the existing before_tool_call hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **openclaw-aport plugin: `aport_check` and `aport_passport` optional agent tools.** Agents can now query their own authorization state before executing sensitive operations, and read or scaffold their APort passport. Both tools are opt-in (`optional: true`). Reuses existing hook helpers (no duplication).
+
 ## [1.0.15] - 2026-03-12
 
 ### Added

--- a/extensions/openclaw-aport/index.js
+++ b/extensions/openclaw-aport/index.js
@@ -31,8 +31,9 @@
  */
 
 import { spawn } from "child_process";
-import { createHash } from "crypto";
-import { readFile, mkdir } from "fs/promises";
+import { createHash, randomUUID } from "crypto";
+import { readFile, writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
 
@@ -407,6 +408,155 @@ export default function (api) {
     log(`[${name}] Tool completed: ${toolName}`);
     // Could log to audit trail here
   });
+
+  // --- Optional agent tools (opt-in via agents.list[].tools.allow) ---
+
+  if (typeof api.registerTool === "function") {
+    api.registerTool(
+      {
+        name: "aport_check",
+        label: "APort Authorization Check",
+        description:
+          "Check whether a tool call is authorized by the APort OAP policy before executing it. Returns {allowed, policy, reason}.",
+        parameters: {
+          type: "object",
+          properties: {
+            tool_name: {
+              type: "string",
+              description: "The OpenClaw tool name to check (e.g. 'exec', 'message', 'write')",
+            },
+            params: {
+              type: "object",
+              description: "The parameters that would be passed to the tool",
+              additionalProperties: true,
+            },
+          },
+          required: ["tool_name"],
+        },
+        async execute(_id, params) {
+          const policyName = mapToolToPolicy(params.tool_name);
+          let result;
+          try {
+            if (!policyName) {
+              result = allowUnmappedTools
+                ? { allowed: true, policy: null, reason: "No policy mapping — tool allowed (allowUnmappedTools: true)" }
+                : { allowed: false, policy: null, reason: "No policy mapping — tool blocked (allowUnmappedTools: false)" };
+              return { content: [{ type: "text", text: JSON.stringify(result) }], details: result };
+            }
+            const scriptToolName = policyName.replace(/\.v\d+$/, "");
+            let decision;
+            if (mode === "api") {
+              decision = await verifyViaAPI(policyName, params.params || {}, { apiUrl, apiKey, passportFile: agentId ? null : passportFile, agentId });
+            } else {
+              decision = await verifyViaScript(scriptToolName, params.params || {}, { guardrailScript, passportFile });
+            }
+            if (!verifyDecisionIntegrity(decision)) {
+              result = { allowed: false, policy: policyName, reason: "Decision integrity verification failed (content_hash mismatch)" };
+            } else {
+              result = {
+                allowed: Boolean(decision.allow),
+                policy: policyName,
+                reason: decision.reasons?.[0]?.message ?? (decision.allow ? "Allowed" : "Denied"),
+              };
+            }
+          } catch (error) {
+            result = { allowed: false, policy: policyName, reason: error.message };
+          }
+          return { content: [{ type: "text", text: JSON.stringify(result) }], details: result };
+        },
+      },
+      { optional: true },
+    );
+
+    api.registerTool(
+      {
+        name: "aport_passport",
+        label: "APort Passport Manager",
+        description:
+          "Read or generate an APort agent passport. Use action='read' to inspect current capabilities, action='generate' to scaffold a new passport.",
+        parameters: {
+          type: "object",
+          properties: {
+            action: {
+              type: "string",
+              enum: ["read", "generate"],
+              description: "read = return current passport; generate = create default passport file if missing",
+            },
+          },
+          required: ["action"],
+        },
+        async execute(_id, params) {
+          let result;
+          try {
+            if (params.action === "read") {
+              try {
+                const data = await readFile(passportFile, "utf8");
+                const passport = JSON.parse(data);
+                result = {
+                  status: "ok",
+                  passport_id: passport.passport_id ?? passport.agent_id ?? null,
+                  assurance_level: passport.assurance_level ?? null,
+                  capabilities: (passport.capabilities ?? []).map((c) => c.id ?? c),
+                  passport_status: passport.status ?? "unknown",
+                };
+              } catch (readErr) {
+                if (readErr.code === "ENOENT") {
+                  result = {
+                    status: "not_found",
+                    path: passportFile,
+                    hint: "Run action='generate' to create a default passport, or run: npx @aporthq/aport-agent-guardrails openclaw",
+                  };
+                } else {
+                  throw readErr;
+                }
+              }
+            } else {
+              if (existsSync(passportFile)) {
+                result = {
+                  status: "exists",
+                  path: passportFile,
+                  hint: "Passport already exists. Use action='read' to inspect it.",
+                };
+              } else {
+                await mkdir(dirname(passportFile), { recursive: true });
+                const defaultPassport = {
+                  spec_version: "oap/1.0",
+                  passport_id: randomUUID(),
+                  agent_id: "my-openclaw-agent",
+                  owner_id: "configure-me",
+                  status: "active",
+                  assurance_level: "L1",
+                  capabilities: [
+                    { id: "system.command.execute" },
+                    { id: "data.file.read" },
+                    { id: "data.file.write" },
+                    { id: "web.fetch" },
+                  ],
+                  limits: {
+                    "system.command.execute": { allowed_commands: ["*"], blocked_patterns: [] },
+                    "data.file.write": { allowed_paths: ["~/.openclaw/"] },
+                    "web.fetch": { allowed_domains: ["*"] },
+                  },
+                };
+                await writeFile(passportFile, JSON.stringify(defaultPassport, null, 2), "utf8");
+                result = {
+                  status: "created",
+                  path: passportFile,
+                  hint: "Edit this file to restrict capabilities. Restart OpenClaw to apply.",
+                };
+              }
+            }
+          } catch (error) {
+            result = { status: "error", reason: error.message };
+          }
+          return { content: [{ type: "text", text: JSON.stringify(result) }], details: result };
+        },
+      },
+      { optional: true },
+    );
+
+    log(`[${name}] Registered optional tools: aport_check, aport_passport`);
+  }
 
   log(`[${name}] Registered hooks: before_tool_call, after_tool_call`);
 }

--- a/extensions/openclaw-aport/index.ts
+++ b/extensions/openclaw-aport/index.ts
@@ -8,7 +8,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { spawn } from "child_process";
 import { createHash, randomUUID } from "crypto";
-import { readFile, mkdir, appendFile } from "fs/promises";
+import { readFile, writeFile, mkdir, appendFile } from "fs/promises";
 import { appendFileSync, mkdirSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
@@ -259,7 +259,235 @@ const plugin = {
       }
     });
 
+    // --- Optional agent tools (opt-in via agents.list[].tools.allow) ---
+
+    api.registerTool(
+      {
+        name: "aport_check",
+        label: "APort Authorization Check",
+        description:
+          "Check whether a tool call is authorized by the APort OAP policy before executing it. Returns {allowed, policy, reason}. Use before any sensitive operation to verify authorization.",
+        parameters: {
+          type: "object",
+          properties: {
+            tool_name: {
+              type: "string",
+              description:
+                "The OpenClaw tool name to check (e.g. 'exec', 'message', 'write')",
+            },
+            params: {
+              type: "object",
+              description:
+                "The parameters that would be passed to the tool",
+              additionalProperties: true,
+            },
+          },
+          required: ["tool_name"],
+        },
+        async execute(
+          _id: string,
+          params: { tool_name: string; params?: Record<string, unknown> },
+        ) {
+          const policyName = mapToolToPolicy(params.tool_name);
+          let result: {
+            allowed: boolean;
+            policy: string | null;
+            reason: string;
+          };
+
+          try {
+            if (!policyName) {
+              result = allowUnmappedTools
+                ? {
+                    allowed: true,
+                    policy: null,
+                    reason:
+                      "No policy mapping — tool allowed (allowUnmappedTools: true)",
+                  }
+                : {
+                    allowed: false,
+                    policy: null,
+                    reason:
+                      "No policy mapping — tool blocked (allowUnmappedTools: false)",
+                  };
+              return {
+                content: [{ type: "text" as const, text: JSON.stringify(result) }],
+                details: result,
+              };
+            }
+
+            const scriptToolName = policyName.replace(/\.v\d+$/, "");
+            let decision: any;
+            if (mode === "api") {
+              decision = await verifyViaAPI(policyName, params.params || {}, {
+                apiUrl,
+                apiKey,
+                passportFile: agentId ? null : passportFile,
+                agentId,
+              });
+              const configDir = dirname(passportFile);
+              const auditLogPath = join(configDir, "audit.log");
+              logAuditEntry(auditLogPath, {
+                tool: params.tool_name,
+                allow: Boolean(decision.allow),
+                policy: policyName,
+                code: decision.reasons?.[0]?.code,
+                agentId: agentId || undefined,
+                context: `aport_check:${params.tool_name}`,
+              });
+            } else {
+              decision = await verifyViaScript(
+                scriptToolName,
+                params.params || {},
+                { guardrailScript, passportFile },
+              );
+            }
+
+            if (!verifyDecisionIntegrity(decision)) {
+              result = {
+                allowed: false,
+                policy: policyName,
+                reason:
+                  "Decision integrity verification failed (content_hash mismatch)",
+              };
+            } else {
+              result = {
+                allowed: Boolean(decision.allow),
+                policy: policyName,
+                reason:
+                  decision.reasons?.[0]?.message ??
+                  (decision.allow ? "Allowed" : "Denied"),
+              };
+            }
+          } catch (error: any) {
+            result = {
+              allowed: false,
+              policy: policyName,
+              reason: error.message,
+            };
+          }
+
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result) }],
+            details: result,
+          };
+        },
+      } as any,
+      { optional: true },
+    );
+
+    api.registerTool(
+      {
+        name: "aport_passport",
+        label: "APort Passport Manager",
+        description:
+          "Read or generate an APort agent passport (agent-passport.yaml / passport.json). Use action='read' to inspect current capabilities, action='generate' to scaffold a new passport.",
+        parameters: {
+          type: "object",
+          properties: {
+            action: {
+              type: "string",
+              enum: ["read", "generate"],
+              description:
+                "read = return current passport; generate = create default passport file if missing",
+            },
+          },
+          required: ["action"],
+        },
+        async execute(
+          _id: string,
+          params: { action: "read" | "generate" },
+        ) {
+          let result: Record<string, unknown>;
+
+          try {
+            if (params.action === "read") {
+              try {
+                const data = await readFile(passportFile, "utf8");
+                const passport = JSON.parse(data);
+                result = {
+                  status: "ok",
+                  passport_id:
+                    passport.passport_id ?? passport.agent_id ?? null,
+                  assurance_level: passport.assurance_level ?? null,
+                  capabilities: (passport.capabilities ?? []).map(
+                    (c: any) => c.id ?? c,
+                  ),
+                  passport_status: passport.status ?? "unknown",
+                };
+              } catch (readErr: any) {
+                if (readErr.code === "ENOENT") {
+                  result = {
+                    status: "not_found",
+                    path: passportFile,
+                    hint: "Run action='generate' to create a default passport, or run: npx @aporthq/aport-agent-guardrails openclaw",
+                  };
+                } else {
+                  throw readErr;
+                }
+              }
+            } else {
+              // action === "generate"
+              if (existsSync(passportFile)) {
+                result = {
+                  status: "exists",
+                  path: passportFile,
+                  hint: "Passport already exists. Use action='read' to inspect it.",
+                };
+              } else {
+                await mkdir(dirname(passportFile), { recursive: true });
+                const defaultPassport = {
+                  spec_version: "oap/1.0",
+                  passport_id: randomUUID(),
+                  agent_id: "my-openclaw-agent",
+                  owner_id: "configure-me",
+                  status: "active",
+                  assurance_level: "L1",
+                  capabilities: [
+                    { id: "system.command.execute" },
+                    { id: "data.file.read" },
+                    { id: "data.file.write" },
+                    { id: "web.fetch" },
+                  ],
+                  limits: {
+                    "system.command.execute": {
+                      allowed_commands: ["*"],
+                      blocked_patterns: [],
+                    },
+                    "data.file.write": { allowed_paths: ["~/.openclaw/"] },
+                    "web.fetch": { allowed_domains: ["*"] },
+                  },
+                };
+                await writeFile(
+                  passportFile,
+                  JSON.stringify(defaultPassport, null, 2),
+                  "utf8",
+                );
+                result = {
+                  status: "created",
+                  path: passportFile,
+                  hint: "Edit this file to restrict capabilities. Restart OpenClaw to apply.",
+                };
+              }
+            }
+          } catch (error: any) {
+            result = {
+              status: "error",
+              reason: error.message,
+            };
+          }
+
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(result) }],
+            details: result,
+          };
+        },
+      } as any,
+      { optional: true },
+    );
+
     log(`[APort] Registered hooks: before_tool_call`);
+    log(`[APort] Registered optional tools: aport_check, aport_passport`);
   },
 };
 

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",
   "type": "module",

--- a/extensions/openclaw-aport/test.js
+++ b/extensions/openclaw-aport/test.js
@@ -13,7 +13,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
-import {
+import plugin, {
   mapToolToPolicy,
   canonicalize,
   verifyDecisionIntegrity,
@@ -301,6 +301,196 @@ describe('integration (guardrail script)', () => {
       'second decision should chain',
     );
     assert.ok(verifyDecisionIntegrity(dec2), 'second decision must verify');
+
+    await rm(tmp, { recursive: true, force: true });
+  });
+});
+
+// --- Agent tool registration and behavior tests ---
+
+describe('aport_check and aport_passport tool registration', () => {
+  it('registers both tools with optional: true', () => {
+    const registeredTools = [];
+    const mockApi = {
+      pluginConfig: { mode: 'local', passportFile: '/tmp/nonexistent-passport.json' },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      on: () => {},
+      registerTool: (def, opts) => {
+        registeredTools.push({ name: def.name, opts, parameters: def.parameters, execute: def.execute });
+      },
+    };
+
+    plugin(mockApi);
+
+    const checkTool = registeredTools.find((t) => t.name === 'aport_check');
+    const passportTool = registeredTools.find((t) => t.name === 'aport_passport');
+
+    assert.ok(checkTool, 'aport_check tool must be registered');
+    assert.ok(passportTool, 'aport_passport tool must be registered');
+    assert.deepStrictEqual(checkTool.opts, { optional: true });
+    assert.deepStrictEqual(passportTool.opts, { optional: true });
+
+    // Verify parameter schemas
+    assert.ok(checkTool.parameters.properties.tool_name, 'aport_check must have tool_name param');
+    assert.ok(checkTool.parameters.properties.params, 'aport_check must have params param');
+    assert.deepStrictEqual(checkTool.parameters.required, ['tool_name']);
+
+    assert.ok(passportTool.parameters.properties.action, 'aport_passport must have action param');
+    assert.deepStrictEqual(passportTool.parameters.required, ['action']);
+  });
+});
+
+describe('aport_check tool behavior', () => {
+  /** Helper: register plugin and extract tool executors */
+  function getTools(configOverrides = {}) {
+    const registeredTools = {};
+    const mockApi = {
+      pluginConfig: {
+        mode: 'local',
+        passportFile: '/tmp/nonexistent-passport.json',
+        guardrailScript: '/tmp/nonexistent-guardrail.sh',
+        ...configOverrides,
+      },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      on: () => {},
+      registerTool: (def, _opts) => {
+        registeredTools[def.name] = def.execute;
+      },
+    };
+    plugin(mockApi);
+    return registeredTools;
+  }
+
+  it('returns allowed:false for unmapped tool (allowUnmappedTools=false)', async () => {
+    const tools = getTools({ allowUnmappedTools: false });
+    const result = await tools.aport_check('id-1', { tool_name: 'unknown.tool.xyz' });
+    const parsed = JSON.parse(result.content[0].text);
+    assert.strictEqual(parsed.allowed, false);
+    assert.strictEqual(parsed.policy, null);
+    assert.ok(parsed.reason.includes('allowUnmappedTools: false'));
+  });
+
+  it('returns allowed:true for unmapped tool (allowUnmappedTools=true)', async () => {
+    const tools = getTools({ allowUnmappedTools: true });
+    const result = await tools.aport_check('id-2', { tool_name: 'unknown.tool.xyz' });
+    const parsed = JSON.parse(result.content[0].text);
+    assert.strictEqual(parsed.allowed, true);
+    assert.strictEqual(parsed.policy, null);
+    assert.ok(parsed.reason.includes('allowUnmappedTools: true'));
+  });
+
+  it('returns allowed:false with error reason when guardrail script missing', async () => {
+    const tools = getTools({ mode: 'local', guardrailScript: '/tmp/no-such-script.sh' });
+    const result = await tools.aport_check('id-3', { tool_name: 'exec', params: { command: 'ls' } });
+    const parsed = JSON.parse(result.content[0].text);
+    assert.strictEqual(parsed.allowed, false);
+    assert.strictEqual(parsed.policy, 'system.command.execute.v1');
+    assert.ok(parsed.reason.length > 0, 'should have error reason');
+  });
+
+  it('returns structured content with type:text', async () => {
+    const tools = getTools({ allowUnmappedTools: true });
+    const result = await tools.aport_check('id-4', { tool_name: 'some.tool' });
+    assert.ok(Array.isArray(result.content));
+    assert.strictEqual(result.content[0].type, 'text');
+    const parsed = JSON.parse(result.content[0].text);
+    assert.ok('allowed' in parsed);
+    assert.ok('policy' in parsed);
+    assert.ok('reason' in parsed);
+  });
+});
+
+describe('aport_passport tool behavior', () => {
+  function getTools(configOverrides = {}) {
+    const registeredTools = {};
+    const mockApi = {
+      pluginConfig: {
+        mode: 'local',
+        ...configOverrides,
+      },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      on: () => {},
+      registerTool: (def, _opts) => {
+        registeredTools[def.name] = def.execute;
+      },
+    };
+    plugin(mockApi);
+    return registeredTools;
+  }
+
+  it('read — returns passport data when file exists', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'aport-passport-test-'));
+    const passportPath = join(tmp, 'passport.json');
+    const passport = {
+      spec_version: 'oap/1.0',
+      passport_id: 'test-id-123',
+      agent_id: 'test-agent',
+      status: 'active',
+      assurance_level: 'L2',
+      capabilities: [{ id: 'system.command.execute' }, { id: 'data.file.read' }],
+    };
+    await writeFile(passportPath, JSON.stringify(passport));
+
+    const tools = getTools({ passportFile: passportPath });
+    const result = await tools.aport_passport('id-1', { action: 'read' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    assert.strictEqual(parsed.status, 'ok');
+    assert.strictEqual(parsed.passport_id, 'test-id-123');
+    assert.strictEqual(parsed.assurance_level, 'L2');
+    assert.deepStrictEqual(parsed.capabilities, ['system.command.execute', 'data.file.read']);
+    assert.strictEqual(parsed.passport_status, 'active');
+
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('read — returns not_found when file missing', async () => {
+    const tools = getTools({ passportFile: '/tmp/no-such-dir/no-passport.json' });
+    const result = await tools.aport_passport('id-2', { action: 'read' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    assert.strictEqual(parsed.status, 'not_found');
+    assert.ok(parsed.hint.includes('generate'));
+  });
+
+  it('generate — creates passport file when missing', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'aport-passport-gen-'));
+    const passportPath = join(tmp, 'subdir', 'passport.json');
+
+    const tools = getTools({ passportFile: passportPath });
+    const result = await tools.aport_passport('id-3', { action: 'generate' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    assert.strictEqual(parsed.status, 'created');
+    assert.ok(parsed.hint.includes('Edit'));
+
+    // Verify file was created with valid content
+    const fileContent = JSON.parse(await readFile(passportPath, 'utf8'));
+    assert.strictEqual(fileContent.spec_version, 'oap/1.0');
+    assert.strictEqual(fileContent.status, 'active');
+    assert.ok(fileContent.passport_id, 'should have passport_id (UUID)');
+    assert.ok(Array.isArray(fileContent.capabilities));
+    assert.ok(fileContent.capabilities.length >= 4);
+
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('generate — returns exists when passport already present', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'aport-passport-exists-'));
+    const passportPath = join(tmp, 'passport.json');
+    const original = JSON.stringify({ spec_version: 'oap/1.0', passport_id: 'existing' });
+    await writeFile(passportPath, original);
+
+    const tools = getTools({ passportFile: passportPath });
+    const result = await tools.aport_passport('id-4', { action: 'generate' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    assert.strictEqual(parsed.status, 'exists');
+    assert.ok(parsed.hint.includes('read'));
+
+    // Verify file was NOT overwritten
+    const fileContent = await readFile(passportPath, 'utf8');
+    assert.strictEqual(fileContent, original);
 
     await rm(tmp, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Description

Adds two optional, opt-in agent tools to the `extensions/openclaw-aport` OpenClaw plugin:

### `aport_check`
Lets the agent query whether a specific tool call is authorized by its OAP passport **before** executing it.

**Usage:** Opt-in via `agents.list[].tools.allow: ["aport_check"]`

**Returns:** `{ allowed: boolean, policy: string | null, reason: string }`

**Design:** Reuses existing helpers `mapToolToPolicy`, `verifyViaScript`/`verifyViaAPI`, and `verifyDecisionIntegrity` from the existing hook. No logic duplication.

### `aport_passport`
Lets the agent inspect its current passport or scaffold a new one.

**Usage:** Opt-in via `agents.list[].tools.allow: ["aport_passport"]`

**Actions:**
- `read` → returns passport_id, assurance_level, capabilities, status
- `generate` → creates a default passport.json at the configured path (no-op if already exists)

## Type of Change
- [x] New feature

## Architecture notes
- Both tools registered with `optional: true` — never auto-enabled
- Existing `before_tool_call` hook is **untouched** (zero regression risk)
- All closure variables (`mode`, `passportFile`, `guardrailScript`, `apiUrl`, `apiKey`, etc.) captured from surrounding `register()` — same as hook
- DRY: no duplication of existing helper logic

## Release workflow impact
`@aporthq/openclaw-aport` IS a workspace package (listed in root `package.json` workspaces). However, the release workflow (`release.yml`) only publishes root + core + langchain + crewai + cursor + claude-code packages via explicit `-w` flags. It does **not** publish `@aporthq/openclaw-aport`. The package is also NOT in the `.changeset/config.json` fixed version group. Therefore this version bump (1.0.10 → 1.1.0) has **no impact** on the release workflow.

## Testing
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — all 30 tests pass (21 existing + 9 new)
- [x] Tool registration verified with mocked API
- [x] Gate 1 (EngineerBot): passed
- [x] Gate 2 (SrEngineerBot architecture review): passed
- [x] Gate 3 (SrEngineerBot QA 35/35): passed

## Checklist
- [x] Code follows project style guidelines (ESM, TypeScript strict, existing patterns)
- [x] Self-review completed
- [x] No new warnings generated
- [x] Tests added/updated (9 new cases, 30 total)
- [x] CHANGELOG.md updated
- [x] Changeset created (`.changeset/feat-openclaw-agent-tools.md`)
- [x] Version bumped: openclaw-aport 1.0.10 → 1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)