### PR TITLE
fix: sync-version.mjs updates all packages, bump to v1.0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "workspaces": [
     "packages/*",

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-claude-code",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "APort guardrails for Claude Code — PreToolUse hook",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
   "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
   "main": "index.js",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/python/aport_guardrails/__init__.py
+++ b/python/aport_guardrails/__init__.py
@@ -3,7 +3,7 @@ aport_guardrails — Core evaluator, passport, and config for APort agent guardr
 Shared across Python framework adapters (LangChain, CrewAI, AutoGen).
 """
 
-__version__ = "1.0.16"
+__version__ = "1.0.17"
 
 from aport_guardrails.core.evaluator import Evaluator, Decision, ToolContext
 from aport_guardrails.core.passport import load_passport, validate_passport

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.16"
+version = "1.0.17"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.16"
+version = "1.0.17"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.16"
+version = "1.0.17"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,16 +1,8 @@
 #!/usr/bin/env node
-/**
- * Sync version from root package.json to all Python packages.
- * Run after `changeset version` so Node and Python share the same version.
- *
- * Updates:
- * - python/aport_guardrails/pyproject.toml [project].version
- * - python/aport_guardrails/__init__.py __version__
- * - python/langchain_adapter/pyproject.toml [project].version
- * - python/crewai_adapter/pyproject.toml [project].version
- */
+// Sync version from root package.json to ALL Node + Python sub-packages.
+// Run after `changeset version` so everything shares the same version.
 
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 
@@ -23,6 +15,31 @@ if (!version) {
   process.exit(1);
 }
 
+console.log(`sync-version: syncing all packages to ${version}`);
+
+// --- Node workspace packages ---
+const packagesDir = join(root, "packages");
+try {
+  const entries = readdirSync(packagesDir);
+  for (const entry of entries) {
+    const pkgJsonPath = join(packagesDir, entry, "package.json");
+    try {
+      const stat = statSync(pkgJsonPath);
+      if (stat.isFile()) {
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+        pkg.version = version;
+        writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+        console.log(`Updated packages/${entry}/package.json -> ${version}`);
+      }
+    } catch (e) {
+      // No package.json in this dir, skip
+    }
+  }
+} catch (e) {
+  console.warn("sync-version: could not read packages/ directory:", e.message);
+}
+
+// --- Python packages ---
 const pyPackages = [
   { dir: "python/aport_guardrails", pyproject: "pyproject.toml", init: "__init__.py" },
   { dir: "python/langchain_adapter", pyproject: "pyproject.toml" },


### PR DESCRIPTION
## Summary

Fix version sync script to update npm workspace packages (not just Python).
Bump all packages to v1.0.17.

## Root cause

`sync-version.mjs` only synced Python packages. The 7 npm workspace packages
stayed at 1.0.15 when root was bumped to 1.0.16, causing the v1.0.16 release
to fail (npm 403 on root, workspace version mismatch).

## Fix

- `sync-version.mjs` now reads `packages/*/package.json` and updates all of them
- All 11 packages (7 npm + 3 PyPI + __init__) synced to 1.0.17

## Test

- `make test` 30/30
- `npm run build` clean
- `node scripts/sync-version.mjs` updates all 11 packages
