### PR TITLE
fix: CI Node 22, shfmt formatting, pre-commit hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,10 @@ indent_size = 2
 
 [*.{sh,bash}]
 indent_style = space
-indent_size = 2
+indent_size = 4
+binary_next_line = true
+switch_case_indent = true
+space_redirects = true
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install Node dependencies

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Check shell script formatting
         run: |
-          # Check formatting (don't modify files, just report issues)
-          find bin tests -name "*.sh" -type f -print0 | xargs -0 shfmt -d -i 4 -bn -ci -sr
+          # Check formatting (reads config from .editorconfig)
+          find bin tests -name "*.sh" -type f -print0 | xargs -0 shfmt -d
 
       - name: Comment on PR (if formatting issues found)
         if: failure() && github.event_name == 'pull_request'
@@ -70,5 +70,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ **Shell formatting issues detected!**\n\nRun `shfmt -w -i 4 -bn -ci -sr bin/**/*.sh tests/**/*.sh` to auto-format.\n\nSee the workflow run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+              body: '⚠️ **Shell formatting issues detected!**\n\nRun `shfmt -w bin/**/*.sh tests/**/*.sh` to auto-format (reads config from .editorconfig).\n\nSee the workflow run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             })

--- a/bin/aport-create-passport.sh
+++ b/bin/aport-create-passport.sh
@@ -282,9 +282,9 @@ else
     echo "  ───────────────"
     case "${APORT_FRAMEWORK:-}" in
         claude-code) echo "  Choose what your agent can do (y/n). Claude Code defaults: most capabilities = yes." ;;
-        cursor)      echo "  Choose what your agent can do (y/n). Cursor defaults: file ops, exec, web, sub-agents = yes." ;;
-        openclaw)    echo "  Choose what your agent can do (y/n). OpenClaw defaults: PRs, exec, messaging, file ops = yes." ;;
-        *)           echo "  Choose what your agent can do (y/n). Defaults: PRs, exec, and messaging = yes; others vary by framework." ;;
+        cursor) echo "  Choose what your agent can do (y/n). Cursor defaults: file ops, exec, web, sub-agents = yes." ;;
+        openclaw) echo "  Choose what your agent can do (y/n). OpenClaw defaults: PRs, exec, messaging, file ops = yes." ;;
+        *) echo "  Choose what your agent can do (y/n). Defaults: PRs, exec, and messaging = yes; others vary by framework." ;;
     esac
     echo ""
     read -p "  • Create and merge pull requests? [Y/n]: " pr_cap

--- a/bin/lib/agentsmd.sh
+++ b/bin/lib/agentsmd.sh
@@ -32,7 +32,7 @@ resolve_agentsmd_enforcement() {
     while IFS= read -r line; do
         if [ "$in_frontmatter" -eq 0 ]; then
             [ "$line" = "---" ] && in_frontmatter=1 && continue
-            return 1  # first line isn't ---, no frontmatter
+            return 1 # first line isn't ---, no frontmatter
         fi
         [ "$line" = "---" ] && break
         frontmatter+="$line"$'\n'
@@ -61,7 +61,7 @@ resolve_agentsmd_enforcement() {
             key="$(echo "$line" | sed -n 's/^[[:space:]]*\([a-z_]*\):.*/\1/p')"
             val="$(echo "$line" | sed -n 's/^[[:space:]]*[a-z_]*:[[:space:]]*//p' | sed 's/[[:space:]]*#.*$//' | sed 's/^["'"'"']\(.*\)["'"'"']$/\1/')"
             case "$key" in
-                engine)   AGENTSMD_ENGINE="$val" ;;
+                engine) AGENTSMD_ENGINE="$val" ;;
                 passport)
                     # Resolve relative paths against AGENTS.md location
                     if [[ "$val" == ./* ]]; then
@@ -85,7 +85,7 @@ resolve_agentsmd_enforcement() {
 # Used by framework setup scripts (claude-code.sh, cursor.sh) to avoid duplicating logic.
 # Requires: log_info (from common.sh), run_passport_wizard (from passport.sh).
 setup_from_agentsmd_or_wizard() {
-    if resolve_agentsmd_enforcement 2>/dev/null; then
+    if resolve_agentsmd_enforcement 2> /dev/null; then
         if [ -n "$AGENTSMD_AGENT_ID" ]; then
             log_info "Found AGENTS.md enforcement block with agent_id: $AGENTSMD_AGENT_ID"
             log_info "Using hosted passport — skipping wizard."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -30,36 +30,29 @@
     },
     "extensions/openclaw-aport": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.10",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^18.0.0",
-        "openclaw": "^2026.3.23",
+        "@types/node": "^22.0.0",
+        "openclaw": ">=2026.3.0",
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "openclaw": ">=2026.2.0"
+        "openclaw": ">=2026.3.0"
       }
     },
     "extensions/openclaw-aport/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
-    },
-    "extensions/openclaw-aport/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@agentclientprotocol/sdk": {
       "version": "0.16.1",
@@ -11999,7 +11992,7 @@
     },
     "packages/claude-code": {
       "name": "@aporthq/aport-agent-guardrails-claude-code",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.15"
@@ -12014,7 +12007,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -12033,7 +12026,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.15"
@@ -12048,7 +12041,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.15"
@@ -12063,7 +12056,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -12080,7 +12073,7 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.15",
@@ -12099,7 +12092,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.15"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Pre-commit hook: lint and format-check staged files before committing.
+# Install: make install-git-hooks  or  git config core.hooksPath scripts/git-hooks
+#
+# Checks (all sub-second):
+#   1. shfmt   — shell formatting (reads config from .editorconfig)
+#   2. shellcheck — shell bugs (severity=error only)
+#   3. node --check — JS/MJS syntax
+#   4. python3 ast.parse — Python syntax
+
+set -e
+
+STAGED_SH=$(git diff --cached --name-only --diff-filter=ACM -- '*.sh' | head -50)
+STAGED_JS=$(git diff --cached --name-only --diff-filter=ACM -- '*.js' '*.mjs' | head -50)
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM -- '*.py' | head -50)
+
+FAIL=0
+
+# 1. shfmt (shell formatting)
+if [ -n "$STAGED_SH" ] && command -v shfmt >/dev/null 2>&1; then
+	if ! echo "$STAGED_SH" | xargs shfmt -d 2>&1; then
+		echo ""
+		echo "Fix: shfmt -w <files>  (reads config from .editorconfig)"
+		FAIL=1
+	fi
+fi
+
+# 2. shellcheck (shell bugs)
+if [ -n "$STAGED_SH" ] && command -v shellcheck >/dev/null 2>&1; then
+	if ! echo "$STAGED_SH" | xargs shellcheck --severity=error 2>&1; then
+		FAIL=1
+	fi
+fi
+
+# 3. node --check (JS syntax)
+if [ -n "$STAGED_JS" ] && command -v node >/dev/null 2>&1; then
+	for f in $STAGED_JS; do
+		if ! node --check "$f" 2>&1; then
+			FAIL=1
+		fi
+	done
+fi
+
+# 4. python3 ast.parse (Python syntax)
+if [ -n "$STAGED_PY" ] && command -v python3 >/dev/null 2>&1; then
+	for f in $STAGED_PY; do
+		if ! python3 -c "import ast; ast.parse(open('$f').read(), '$f')" 2>&1; then
+			echo "Syntax error: $f"
+			FAIL=1
+		fi
+	done
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+	echo ""
+	echo "Pre-commit checks failed. Fix the issues above or skip with --no-verify."
+	exit 1
+fi

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -4,12 +4,12 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 if [ -z "$REPO_ROOT" ]; then
-    exit 0
+	exit 0
 fi
 
 # Only run if we have submodules
 if [ ! -f "$REPO_ROOT/.gitmodules" ]; then
-    exit 0
+	exit 0
 fi
 
 "$REPO_ROOT/scripts/ensure-submodules-updated.sh" --update-remote

--- a/tests/test_agentsmd.sh
+++ b/tests/test_agentsmd.sh
@@ -26,7 +26,7 @@ assert_eq() {
 run_in_dir() {
     # Run resolve_agentsmd_enforcement in the given dir without subshell
     pushd "$1" > /dev/null
-    resolve_agentsmd_enforcement 2>/dev/null
+    resolve_agentsmd_enforcement 2> /dev/null
     local rc=$?
     popd > /dev/null
     return $rc
@@ -91,18 +91,22 @@ version: 1.0
 # Instructions
 EOF
 if run_in_dir "$t"; then
-    FAIL=$((FAIL + 1)); echo "  ✗ should return 1"
+    FAIL=$((FAIL + 1))
+    echo "  ✗ should return 1"
 else
-    PASS=$((PASS + 1)); echo "  ✓ returns 1"
+    PASS=$((PASS + 1))
+    echo "  ✓ returns 1"
 fi
 
 # --- Test 5: No AGENTS.md ---
 echo "Test 5: No AGENTS.md"
 t="$TMPDIR_BASE/t5" && mkdir -p "$t"
 if run_in_dir "$t"; then
-    FAIL=$((FAIL + 1)); echo "  ✗ should return 1"
+    FAIL=$((FAIL + 1))
+    echo "  ✗ should return 1"
 else
-    PASS=$((PASS + 1)); echo "  ✓ returns 1"
+    PASS=$((PASS + 1))
+    echo "  ✓ returns 1"
 fi
 
 # --- Test 6: No frontmatter ---
@@ -112,9 +116,11 @@ cat > "$t/AGENTS.md" << 'EOF'
 # Just instructions, no frontmatter.
 EOF
 if run_in_dir "$t"; then
-    FAIL=$((FAIL + 1)); echo "  ✗ should return 1"
+    FAIL=$((FAIL + 1))
+    echo "  ✗ should return 1"
 else
-    PASS=$((PASS + 1)); echo "  ✓ returns 1"
+    PASS=$((PASS + 1))
+    echo "  ✓ returns 1"
 fi
 
 # --- Test 7: .agents.md (dotfile variant) ---

--- a/tests/test_resolve_paths_agentsmd.sh
+++ b/tests/test_resolve_paths_agentsmd.sh
@@ -38,12 +38,15 @@ enforcement:
 EOF
 
 # Clear env to ensure clean state
-unset OPENCLAW_PASSPORT_FILE OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG 2>/dev/null || true
-unset PASSPORT_FILE DECISION_FILE AUDIT_LOG 2>/dev/null || true
+unset OPENCLAW_PASSPORT_FILE OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG 2> /dev/null || true
+unset PASSPORT_FILE DECISION_FILE AUDIT_LOG 2> /dev/null || true
 (
     cd "$t"
     source "$SCRIPT_DIR/bin/aport-resolve-paths.sh"
-    [ "$PASSPORT_FILE" = "$t/.aport/passport.json" ] || { echo "  ✗ PASSPORT_FILE=$PASSPORT_FILE"; exit 1; }
+    [ "$PASSPORT_FILE" = "$t/.aport/passport.json" ] || {
+        echo "  ✗ PASSPORT_FILE=$PASSPORT_FILE"
+        exit 1
+    }
     echo "  ✓ PASSPORT_FILE resolved from AGENTS.md"
 )
 PASS=$((PASS + 1))
@@ -66,9 +69,12 @@ EOF
 (
     cd "$t"
     export OPENCLAW_PASSPORT_FILE="$t/override/passport.json"
-    unset OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG 2>/dev/null || true
+    unset OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG 2> /dev/null || true
     source "$SCRIPT_DIR/bin/aport-resolve-paths.sh"
-    [ "$PASSPORT_FILE" = "$t/override/passport.json" ] || { echo "  ✗ Override failed: PASSPORT_FILE=$PASSPORT_FILE"; exit 1; }
+    [ "$PASSPORT_FILE" = "$t/override/passport.json" ] || {
+        echo "  ✗ Override failed: PASSPORT_FILE=$PASSPORT_FILE"
+        exit 1
+    }
     echo "  ✓ Explicit env var takes precedence over AGENTS.md"
 )
 PASS=$((PASS + 1))
@@ -87,9 +93,12 @@ EOF
 
 (
     cd "$t"
-    unset OPENCLAW_PASSPORT_FILE OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG APORT_AGENT_ID 2>/dev/null || true
+    unset OPENCLAW_PASSPORT_FILE OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG APORT_AGENT_ID 2> /dev/null || true
     source "$SCRIPT_DIR/bin/aport-resolve-paths.sh"
-    [ "$APORT_AGENT_ID" = "ap_test1234" ] || { echo "  ✗ APORT_AGENT_ID=$APORT_AGENT_ID"; exit 1; }
+    [ "$APORT_AGENT_ID" = "ap_test1234" ] || {
+        echo "  ✗ APORT_AGENT_ID=$APORT_AGENT_ID"
+        exit 1
+    }
     echo "  ✓ APORT_AGENT_ID set from AGENTS.md"
 )
 PASS=$((PASS + 1))
@@ -100,7 +109,7 @@ t="$TMPDIR_BASE/t4"
 mkdir -p "$t"
 (
     cd "$t"
-    unset OPENCLAW_PASSPORT_FILE OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG APORT_AGENT_ID 2>/dev/null || true
+    unset OPENCLAW_PASSPORT_FILE OPENCLAW_DECISION_FILE OPENCLAW_AUDIT_LOG APORT_AGENT_ID 2> /dev/null || true
     source "$SCRIPT_DIR/bin/aport-resolve-paths.sh"
     # Should fall through to default path probe — no AGENTS.md, no error
     echo "  ✓ No AGENTS.md — fell through to default resolution"

--- a/tests/unit/test-passport-framework-defaults.sh
+++ b/tests/unit/test-passport-framework-defaults.sh
@@ -20,7 +20,7 @@ assert_eq() {
 run_noninteractive_for_framework() {
     local framework="$1"
     local out_file="$2"
-    APORT_FRAMEWORK="$framework" "$PASSPORT_SCRIPT" --framework="$framework" --non-interactive --output "$out_file" >/dev/null
+    APORT_FRAMEWORK="$framework" "$PASSPORT_SCRIPT" --framework="$framework" --non-interactive --output "$out_file" > /dev/null
 }
 
 echo ""


### PR DESCRIPTION
## Summary

- CI: bump Node 20 to 22 (openclaw-aport requires >=22), regenerate package-lock.json
- .editorconfig: fix shell indent 2 to 4 (matches actual code), add shfmt config (bn, ci, sr)
- shellcheck.yml: shfmt now reads config from .editorconfig instead of hardcoded flags
- New pre-commit hook: shfmt, shellcheck, node syntax, python syntax on staged files
- shfmt auto-format on 5 shell scripts that had minor formatting diffs

## Test plan

- [x] shfmt clean on all bin/ and tests/ shell scripts
- [x] shellcheck 0 errors
- [x] npm ci, build, and workspace tests pass
- [x] 31 bash tests pass
- [x] 24 OpenClaw plugin tests pass
