### PR TITLE
fix(openclaw): harden plugin setup and release 1.0.23

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official APort plugins — security guardrails for AI coding agents",
-    "version": "1.0.22",
+    "version": "1.0.23",
     "license": "Apache-2.0",
     "homepage": "https://aport.io"
   },
@@ -17,7 +17,7 @@
       "source": {
         "source": "github",
         "repo": "aporthq/aport-agent-guardrails",
-        "ref": "v1.0.22"
+        "ref": "v1.0.23"
       },
       "keywords": [
         "security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aport-guardrails",
   "description": "APort Agent Guardrails — security policy enforcement for every tool call. Intercepts tool use, evaluates against your passport policy, and blocks unauthorized actions.",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "author": {
     "name": "APort Technologies Inc.",
     "email": "hello@aport.io",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.23] - 2026-04-13
+
+### Fixed
+- **OpenClaw plugin mapping correctness:** the OpenClaw plugin now maps current OpenClaw tool calls more accurately, including `message` send-family actions and MCP bundle tools exposed as `serverName__toolName`, while dropping speculative session, finance, and export mappings that did not match the current host tool surface.
+- **OpenClaw hosted/API context normalization:** hosted evaluation now normalizes OpenClaw file, message, and MCP tool params into the context shape expected by the APort API, avoiding `400` failures caused by mismatched field names like `path` vs `file_path`.
+- **OpenClaw setup idempotence:** `npx @aporthq/aport-agent-guardrails openclaw` now skips plugin reinstall when the same `openclaw-aport` version is already installed, while still reinstalling when versions differ.
+- **OpenClaw direct-install guidance:** docs now explicitly state that `openclaw plugins install @aporthq/openclaw-aport` installs only the plugin bundle and should be followed by the full APort setup command to create a passport and write config.
+
 ## [1.0.22] - 2026-04-13
 
 ### Fixed
 - **OpenClaw public integration:** `npx @aporthq/aport-agent-guardrails openclaw` now ships the scanner-safe plugin runtime, correct compatibility metadata, and installer behavior that stops on plugin install failure instead of writing broken config.
 - **OpenClaw docs and setup guidance:** public docs, quickstarts, and generated setup content now consistently describe the plugin-based OpenClaw path and the value split between OpenClaw security controls and APort authorization.
-
 
 ## [1.0.21] - 2026-04-11
 

--- a/bin/openclaw
+++ b/bin/openclaw
@@ -30,6 +30,48 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 APORT_PLUGIN_PATH="$REPO_ROOT/extensions/openclaw-aport"
 DEFAULT_CONFIG="${OPENCLAW_HOME:-$HOME/.openclaw}"
 
+read_local_plugin_version() {
+    if ! command -v node >/dev/null 2>&1; then
+        return 0
+    fi
+    local package_json="$APORT_PLUGIN_PATH/package.json"
+    if [ ! -f "$package_json" ]; then
+        return 0
+    fi
+    node -e '
+const fs = require("node:fs");
+try {
+  const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  if (pkg && typeof pkg.version === "string") process.stdout.write(pkg.version);
+} catch {}
+' "$package_json"
+}
+
+read_installed_plugin_version() {
+    if ! command -v openclaw >/dev/null 2>&1 || ! command -v node >/dev/null 2>&1; then
+        return 0
+    fi
+    openclaw plugins list --json 2>/dev/null | node -e '
+let raw = "";
+process.stdin.on("data", (chunk) => {
+  raw += chunk;
+});
+process.stdin.on("end", () => {
+  const jsonStart = raw.indexOf("{");
+  if (jsonStart < 0) return;
+  try {
+    const data = JSON.parse(raw.slice(jsonStart));
+    const plugin = Array.isArray(data.plugins)
+      ? data.plugins.find((entry) => entry && entry.id === "openclaw-aport")
+      : null;
+    if (plugin && typeof plugin.version === "string") {
+      process.stdout.write(plugin.version);
+    }
+  } catch {}
+});
+'
+}
+
 # Parse command line arguments
 HOSTED_AGENT_ID=""
 if [ -n "$1" ]; then
@@ -210,19 +252,29 @@ if true; then
             echo "  Skipping plugin installation."
         fi
     else
+        LOCAL_PLUGIN_VERSION="$(read_local_plugin_version)"
+        INSTALLED_PLUGIN_VERSION="$(read_installed_plugin_version)"
         echo ""
-        echo "  Installing plugin from: $APORT_PLUGIN_PATH"
-        echo "  (Using -l to link local directory; OpenClaw accepts only registry or --link for install.)"
-        if openclaw plugins install -l "$APORT_PLUGIN_PATH" 2>&1; then
-            echo "  ✅ Plugin installed successfully"
+        if [ -n "$LOCAL_PLUGIN_VERSION" ] && [ "$LOCAL_PLUGIN_VERSION" = "$INSTALLED_PLUGIN_VERSION" ]; then
+            echo "  ✅ Plugin version $LOCAL_PLUGIN_VERSION already installed; skipping reinstall."
             PLUGIN_INSTALLED=true
         else
-            echo "  ❌ Plugin installation failed."
-            echo "     OpenClaw did not accept the plugin bundle, so setup is stopping here"
-            echo "     instead of writing plugin config that points at a broken install."
-            echo "     Retry after fixing the bundle or install it manually:"
-            echo "     openclaw plugins install -l $APORT_PLUGIN_PATH"
-            exit 1
+            if [ -n "$INSTALLED_PLUGIN_VERSION" ]; then
+                echo "  Existing openclaw-aport version: $INSTALLED_PLUGIN_VERSION"
+            fi
+            echo "  Installing plugin from: $APORT_PLUGIN_PATH"
+            echo "  (Using -l to link local directory; OpenClaw accepts only registry or --link for install.)"
+            if openclaw plugins install -l "$APORT_PLUGIN_PATH" 2>&1; then
+                echo "  ✅ Plugin installed successfully"
+                PLUGIN_INSTALLED=true
+            else
+                echo "  ❌ Plugin installation failed."
+                echo "     OpenClaw did not accept the plugin bundle, so setup is stopping here"
+                echo "     instead of writing plugin config that points at a broken install."
+                echo "     Retry after fixing the bundle or install it manually:"
+                echo "     openclaw plugins install -l $APORT_PLUGIN_PATH"
+                exit 1
+            fi
         fi
         echo ""
 
@@ -590,19 +642,18 @@ echo "   OpenClaw (or your code) calls the guardrail with a tool name and contex
 echo "   The guardrail maps that to a policy pack in external/aport-policies:"
 echo
 cat << 'TABLE'
-   Tool name (examples)              → Policy pack
-   ------------------------------------------------
-   git.create_pr, git.merge, git.*   → code.repository.merge.v1
-   exec.run, system.command.*       → system.command.execute.v1
-   message.send, messaging.*        → messaging.message.send.v1
-   mcp.tool.*, mcp.*                 → mcp.tool.execute.v1
-   agent.session.*, session.*       → agent.session.create.v1
-   agent.tool.*, tool.register      → agent.tool.register.v1
-   payment.refund, finance.*        → finance.payment.refund.v1
-   payment.charge                    → finance.payment.charge.v1
-   database.write, data.export       → data.export.create.v1
+	   Tool name (examples)              → Policy pack
+	   ------------------------------------------------
+	   git.create_pr, git.merge, git.*   → code.repository.merge.v1
+	   exec.run, system.command.*        → system.command.execute.v1
+	   message + send/reply/broadcast    → messaging.message.send.v1
+	   message + sendAttachment/react    → messaging.message.send.v1
+	   serverName__toolName, mcp__*      → mcp.tool.execute.v1
+	   read, glob, grep                  → data.file.read.v1
+	   write, edit, multiedit            → data.file.write.v1
 TABLE
-echo "   Full list: docs/TOOL_POLICY_MAPPING.md"
+echo "   Plugin mapping source: extensions/openclaw-aport/tool-mapping.js"
+echo "   Unmapped tools are allowed by default; set allowUnmappedTools: false for strict mode."
 echo
 
 # 5. Enforcement summary

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release process and version policy
 
-**Current release:** 1.0.22 (see [CHANGELOG.md](../CHANGELOG.md)).
+**Current release:** 1.0.23 (see [CHANGELOG.md](../CHANGELOG.md)).
 
 We keep **one version number** across all published packages (Node core, Python core, and every framework adapter). That avoids “core is 1.2 but CLI is 0.9” and keeps the story simple for users and support.
 

--- a/docs/TOOL_POLICY_MAPPING.md
+++ b/docs/TOOL_POLICY_MAPPING.md
@@ -1,8 +1,8 @@
 # Tool → policy pack mapping
 
-OpenClaw (or any caller) invokes the guardrail with a **tool name** and **context JSON**. The guardrail maps the tool name to a **policy pack** in `external/aport-policies/` and evaluates the request against that policy and the passport.
+The shell/API guardrail entrypoints invoke the guardrail with a **tool name** and **context JSON**. The guardrail maps the tool name to a **policy pack** in `external/aport-policies/` and evaluates the request against that policy and the passport.
 
-This mapping is implemented in `bin/aport-guardrail-api.sh` and `bin/aport-guardrail-bash.sh`. The table below is the single source of truth for documentation.
+This mapping is implemented in `bin/aport-guardrail-api.sh` and `bin/aport-guardrail-bash.sh`. The OpenClaw plugin has its own host-specific mapping in `extensions/openclaw-aport/tool-mapping.js`.
 
 ## Mapping table
 

--- a/docs/frameworks/openclaw.md
+++ b/docs/frameworks/openclaw.md
@@ -14,6 +14,20 @@ If you already have a hosted passport on aport.io, pass the `agent_id` and skip 
 npx @aporthq/aport-agent-guardrails openclaw ap_your_agent_id
 ```
 
+If you run `openclaw plugins install @aporthq/openclaw-aport` directly, that installs only the plugin bundle. It does not create a local passport or write the plugin config. Use the setup command above for the full APort + OpenClaw flow, or configure the plugin manually.
+
+After a direct plugin install, the recommended next step is:
+
+```bash
+npx @aporthq/aport-agent-guardrails openclaw
+```
+
+Hosted passport:
+
+```bash
+npx @aporthq/aport-agent-guardrails openclaw ap_your_agent_id
+```
+
 The setup command:
 
 1. Chooses your OpenClaw config directory
@@ -137,9 +151,10 @@ Common mappings include:
 
 - `exec`, `exec.run` -> `system.command.execute.v1`
 - `git.create_pr`, `git.merge`, `git.push` -> `code.repository.merge.v1`
-- `message.send` -> `messaging.message.send.v1`
+- `message` with send-family actions like `send`, `reply`, `broadcast`, `sendAttachment`, `upload-file`, or `react` -> `messaging.message.send.v1`
 - `read`, `view`, `glob` -> `data.file.read.v1`
 - `write`, `edit`, `multiedit` -> `data.file.write.v1`
+- bundle MCP tools exposed as `serverName__toolName` -> `mcp.tool.execute.v1`
 
 ## Kill switch
 

--- a/extensions/openclaw-aport/CHANGELOG.md
+++ b/extensions/openclaw-aport/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog - APort OpenClaw Plugin
 
+## 1.0.23
+
+### Patch Changes
+
+- Fix the OpenClaw plugin and setup flow for current public OpenClaw releases. This update makes the plugin installer and setup flow more reliable, tightens tool-to-policy mapping for current OpenClaw tools like `message` and MCP bundle tools, normalizes hosted API context for file and message tools, and skips redundant plugin reinstall when the same version is already installed.
+
 All notable changes to the APort OpenClaw plugin will be documented in this file.
 
 ## [1.0.22] - 2026-04-13
 
 ### Fixed
+
 - Replaced the old shell-spawning runtime with a scanner-safe JavaScript plugin runtime for local and API evaluation.
 - Added current OpenClaw compatibility metadata in `package.json` and aligned the hook return shape with the documented `before_tool_call` contract.
 - Kept `alwaysVerifyEachToolCall` as a deprecated manifest field so existing installs continue to load during upgrade.

--- a/extensions/openclaw-aport/README.md
+++ b/extensions/openclaw-aport/README.md
@@ -33,6 +33,28 @@ After setup, start OpenClaw with the generated config:
 openclaw gateway start --config ~/.openclaw/config.yaml
 ```
 
+## If you installed with `openclaw plugins install`
+
+If you installed the plugin directly with:
+
+```bash
+openclaw plugins install @aporthq/openclaw-aport
+```
+
+that installs only the plugin bundle. It does not create a passport, choose API vs local mode, or write plugin config.
+
+Run the full APort setup immediately after install:
+
+```bash
+npx @aporthq/aport-agent-guardrails openclaw
+```
+
+If you already have a hosted passport, use:
+
+```bash
+npx @aporthq/aport-agent-guardrails openclaw ap_your_agent_id
+```
+
 ## What OpenClaw already gives you
 
 OpenClaw already ships sandboxing, tool policy, elevated exec controls, and install-time scanning. Those are real security controls, not marketing copy.
@@ -55,6 +77,12 @@ If you are working from a local checkout, install the plugin directly from the e
 
 ```bash
 openclaw plugins install -l /path/to/aport-agent-guardrails/extensions/openclaw-aport
+```
+
+That command installs only the OpenClaw plugin bundle. It does not create a passport, choose API vs local mode, or write plugin config. For a full working setup, use:
+
+```bash
+npx @aporthq/aport-agent-guardrails openclaw
 ```
 
 Then configure it in your OpenClaw config:
@@ -95,10 +123,10 @@ The plugin keeps the existing OpenClaw-specific tool mappings. Common examples:
 
 - `exec`, `exec.run` -> `system.command.execute.v1`
 - `git.create_pr`, `git.merge`, `git.push` -> `code.repository.merge.v1`
-- `message.send` -> `messaging.message.send.v1`
+- `message` with send-family actions like `send`, `reply`, `broadcast`, `sendAttachment`, `upload-file`, or `react` -> `messaging.message.send.v1`
 - `read`, `view`, `glob` -> `data.file.read.v1`
 - `write`, `edit`, `multiedit` -> `data.file.write.v1`
-- `mcp__*` -> `mcp.tool.execute.v1`
+- bundle MCP tools exposed as `serverName__toolName` -> `mcp.tool.execute.v1`
 
 `allowUnmappedTools: true` keeps the previous OpenClaw compatibility behavior for custom skills and unmapped tools.
 

--- a/extensions/openclaw-aport/api-client.js
+++ b/extensions/openclaw-aport/api-client.js
@@ -14,7 +14,15 @@ export async function verifyViaApi({ apiUrl, apiKey, policyName, context, passpo
   });
 
   if (!response.ok) {
-    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    let details = "";
+    try {
+      const text = await response.text();
+      if (text) details = text;
+    } catch {
+      details = "";
+    }
+    const suffix = details ? ` - ${details}` : "";
+    throw new Error(`API request failed: ${response.status} ${response.statusText}${suffix}`);
   }
 
   const data = await response.json();

--- a/extensions/openclaw-aport/index.js
+++ b/extensions/openclaw-aport/index.js
@@ -13,7 +13,7 @@ import { homedir } from "node:os";
 import { logAuditEntry } from "./audit.js";
 import { canonicalize, formatReasons, verifyDecisionIntegrity } from "./decision.js";
 import { evaluateLocalDecision } from "./local-evaluator.js";
-import { mapToolToPolicy, normalizeExecContext } from "./tool-mapping.js";
+import { mapToolToPolicy, normalizePolicyContext } from "./tool-mapping.js";
 import { verifyViaApi } from "./api-client.js";
 
 export { canonicalize, mapToolToPolicy, verifyDecisionIntegrity };
@@ -48,7 +48,7 @@ export default definePluginEntry({
 
       try {
         const policyName =
-          toolName === "exec" && !mapExecToPolicy ? null : mapToolToPolicy(toolName);
+          toolName === "exec" && !mapExecToPolicy ? null : mapToolToPolicy(toolName, params);
 
         if (!policyName) {
           if (allowUnmappedTools) {
@@ -64,23 +64,22 @@ export default definePluginEntry({
 
         let effectivePolicyName = policyName;
         let effectiveToolName = toolName;
-        let context =
-          policyName === "system.command.execute.v1"
-            ? normalizeExecContext(params, event)
-            : (params || {});
+        let context = normalizePolicyContext(policyName, toolName, params, event);
 
         const delegated = parseGuardrailInvocation(
           effectivePolicyName === "system.command.execute.v1" ? context.command : null,
         );
         if (delegated) {
-          const innerPolicy = mapToolToPolicy(delegated.innerToolName);
+          const innerPolicy = mapToolToPolicy(delegated.innerToolName, delegated.innerContext);
           if (innerPolicy) {
             effectivePolicyName = innerPolicy;
             effectiveToolName = delegated.innerToolName;
-            context =
-              innerPolicy === "system.command.execute.v1"
-                ? normalizeExecContext(delegated.innerContext, { params: delegated.innerContext })
-                : delegated.innerContext;
+            context = normalizePolicyContext(
+              innerPolicy,
+              delegated.innerToolName,
+              delegated.innerContext,
+              { params: delegated.innerContext },
+            );
           }
         }
 

--- a/extensions/openclaw-aport/openclaw.plugin.json
+++ b/extensions/openclaw-aport/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclaw-aport",
   "name": "APort Guardrails",
   "description": "Deterministic pre-action authorization via APort policy enforcement. Registers before_tool_call to block disallowed tools.",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/openclaw-aport/package-lock.json
+++ b/extensions/openclaw-aport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",
   "type": "module",

--- a/extensions/openclaw-aport/tool-mapping.js
+++ b/extensions/openclaw-aport/tool-mapping.js
@@ -1,5 +1,60 @@
-export function mapToolToPolicy(toolName) {
-  const tool = String(toolName ?? "").toLowerCase();
+const MESSAGE_SEND_ACTIONS = new Set([
+  "send",
+  "broadcast",
+  "reply",
+  "thread-reply",
+  "sendwitheffect",
+  "sendattachment",
+  "upload-file",
+  "react",
+]);
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function readAction(params) {
+  const src = params && typeof params === "object" ? params : {};
+  return firstNonEmpty(
+    src.action,
+    src.action_name,
+    src.actionName,
+    src.arguments && typeof src.arguments === "object" ? src.arguments.action : "",
+    src.input && typeof src.input === "object" ? src.input.action : "",
+  ).toLowerCase();
+}
+
+export function parseMcpToolName(toolName) {
+  const raw = String(toolName ?? "").trim();
+  if (!raw) return null;
+
+  if (raw.startsWith("mcp__")) {
+    const parts = raw.split("__");
+    if (parts.length >= 3 && parts[1] && parts.slice(2).join("__")) {
+      return {
+        serverName: parts[1],
+        toolName: parts.slice(2).join("__"),
+      };
+    }
+  }
+
+  const separatorIndex = raw.indexOf("__");
+  if (separatorIndex <= 0 || separatorIndex >= raw.length - 2) {
+    return null;
+  }
+
+  return {
+    serverName: raw.slice(0, separatorIndex),
+    toolName: raw.slice(separatorIndex + 2),
+  };
+}
+
+export function mapToolToPolicy(toolName, params) {
+  const rawTool = String(toolName ?? "").trim();
+  const tool = rawTool.toLowerCase();
 
   if (tool.match(/git\.(create_pr|merge|push|commit)/)) return "code.repository.merge.v1";
   if (tool.startsWith("git.")) return "code.repository.merge.v1";
@@ -10,9 +65,21 @@ export function mapToolToPolicy(toolName) {
   if (tool.startsWith("system.command.")) return "system.command.execute.v1";
   if (tool === "bash" || tool === "shell" || tool === "command") return "system.command.execute.v1";
 
-  if (tool.startsWith("message.")) return "messaging.message.send.v1";
-  if (tool.startsWith("messaging.")) return "messaging.message.send.v1";
-  if (tool.match(/sms|whatsapp|slack|email/)) return "messaging.message.send.v1";
+  if (tool === "message") {
+    return MESSAGE_SEND_ACTIONS.has(readAction(params)) ? "messaging.message.send.v1" : null;
+  }
+  if (
+    tool === "message.send" ||
+    tool === "message.reply" ||
+    tool === "message.broadcast" ||
+    tool === "message.react" ||
+    tool === "messaging.message.send"
+  ) {
+    return "messaging.message.send.v1";
+  }
+  if (tool.match(/(^|[._-])(whatsapp|telegram|slack|email)([._-](send|reply|broadcast|message|react))?$/)) {
+    return "messaging.message.send.v1";
+  }
 
   if (tool === "read") return "data.file.read.v1";
   if (tool.startsWith("file.read")) return "data.file.read.v1";
@@ -24,13 +91,8 @@ export function mapToolToPolicy(toolName) {
   }
   if (tool === "todoread") return "data.file.read.v1";
   if (tool === "todowrite") return "data.file.write.v1";
-  if (tool === "task" || tool === "taskcreate" || tool === "taskupdate" || tool === "taskstop") {
-    return "agent.session.create.v1";
-  }
   if (tool === "taskget" || tool === "tasklist" || tool === "taskoutput") return "data.file.read.v1";
-  if (tool === "agent" || tool === "skill" || tool === "enterworktree") return "agent.session.create.v1";
   if (tool === "askuserquestion" || tool === "enterplanmode" || tool === "exitplanmode") return null;
-  if (tool === "croncreate" || tool === "crondelete") return "agent.session.create.v1";
   if (tool === "cronlist") return "data.file.read.v1";
   if (tool.startsWith("file.write")) return "data.file.write.v1";
   if (tool.startsWith("file.edit")) return "data.file.write.v1";
@@ -45,24 +107,10 @@ export function mapToolToPolicy(toolName) {
   if (tool.startsWith("browser.")) return "web.browser.v1";
 
   if (tool.startsWith("mcp.")) return "mcp.tool.execute.v1";
-  if (tool.startsWith("mcp__")) return "mcp.tool.execute.v1";
-
-  if (tool.match(/agent\.session|session\.create/)) return "agent.session.create.v1";
-  if (tool === "sessions_spawn" || tool === "sessions_send") return "agent.session.create.v1";
-  if (tool.startsWith("session.") || tool.startsWith("sessions.")) return "agent.session.create.v1";
-  if (tool === "cron" || tool.startsWith("cron.")) return "agent.session.create.v1";
+  if (parseMcpToolName(rawTool)) return "mcp.tool.execute.v1";
 
   if (tool === "gateway" || tool.startsWith("gateway.")) return "system.command.execute.v1";
   if (tool === "process" || tool.startsWith("process.")) return "system.command.execute.v1";
-
-  if (tool.match(/agent\.tool|tool\.register/)) return "agent.tool.register.v1";
-
-  if (tool.match(/payment\.refund|refund/)) return "finance.payment.refund.v1";
-  if (tool.match(/payment\.charge|charge/)) return "finance.payment.charge.v1";
-  if (tool.startsWith("finance.")) return "finance.payment.refund.v1";
-
-  if (tool.match(/database\.(write|insert|update|delete)/)) return "data.export.create.v1";
-  if (tool.match(/data\.export|export/)) return "data.export.create.v1";
 
   return null;
 }
@@ -86,4 +134,143 @@ export function normalizeExecContext(params, event) {
   const out = { ...(params || {}), command: full, full_command: full };
   if (params && params.workdir !== undefined && out.cwd === undefined) out.cwd = params.workdir;
   return out;
+}
+
+export function normalizeFileContext(params) {
+  const src = params && typeof params === "object" ? params : {};
+  const filePath =
+    src.file_path ??
+    src.path ??
+    src.filePath ??
+    (src.arguments && typeof src.arguments === "object" ? src.arguments.file_path ?? src.arguments.path : null) ??
+    (src.input && typeof src.input === "object" ? src.input.file_path ?? src.input.path : null) ??
+    (src.args && typeof src.args === "object" ? src.args.file_path ?? src.args.path : null);
+
+  if (filePath == null || String(filePath).trim() === "") {
+    return { ...src };
+  }
+
+  return {
+    ...src,
+    file_path: String(filePath),
+  };
+}
+
+export function normalizeMessageContext(params) {
+  const src = params && typeof params === "object" ? params : {};
+  const action = readAction(src);
+  const firstTarget = Array.isArray(src.targets)
+    ? src.targets.find((value) => typeof value === "string" && value.trim())
+    : "";
+  const channelId = firstNonEmpty(
+    src.channel_id,
+    src.channelId,
+    src.target,
+    firstTarget,
+    src.channel,
+    src.to,
+    src.accountId,
+  );
+  const isAttachmentAction =
+    action === "sendattachment" ||
+    action === "upload-file" ||
+    Boolean(src.media || src.buffer || src.path || src.filePath || src.filename);
+  const messageType = action === "react" ? "reaction" : isAttachmentAction ? "file" : "text";
+  const message = firstNonEmpty(
+    src.message,
+    src.text,
+    src.content,
+    src.caption,
+    src.quoteText,
+    src.emoji,
+    isAttachmentAction ? src.filename : "",
+  );
+  const threadId = firstNonEmpty(src.thread_id, src.threadId);
+  const replyTo = firstNonEmpty(src.reply_to, src.replyTo, src.messageId, src.message_id);
+  const out = {
+    ...src,
+    message_type: src.message_type ?? messageType,
+  };
+
+  if (channelId) out.channel_id = channelId;
+  if (message) out.message = message;
+  else if (messageType === "reaction") out.message = "reaction";
+  else if (messageType === "file") out.message = "[attachment]";
+
+  if (threadId) out.thread_id = threadId;
+  if (replyTo) out.reply_to = replyTo;
+
+  if (!Array.isArray(out.attachments) && isAttachmentAction) {
+    out.attachments = [
+      {
+        ...(typeof src.media === "string" && src.media ? { url: src.media } : {}),
+        ...(typeof src.filename === "string" && src.filename ? { filename: src.filename } : {}),
+      },
+    ];
+  }
+
+  return out;
+}
+
+function buildMcpParameters(src) {
+  if (src.parameters && typeof src.parameters === "object") return src.parameters;
+  if (src.arguments && typeof src.arguments === "object") return src.arguments;
+  if (src.input && typeof src.input === "object") return src.input;
+  if (src.payload && typeof src.payload === "object") return src.payload;
+
+  const {
+    server,
+    server_url,
+    serverUrl,
+    server_name,
+    serverName,
+    tool,
+    tool_name,
+    toolName,
+    parameters,
+    ...rest
+  } = src;
+  return rest;
+}
+
+export function normalizeMcpContext(toolName, params) {
+  const src = params && typeof params === "object" ? params : {};
+  const parsed = parseMcpToolName(toolName);
+  const serverName = firstNonEmpty(
+    src.server,
+    src.server_url,
+    src.serverUrl,
+    src.server_name,
+    src.serverName,
+    src.mcp_server,
+    parsed?.serverName,
+  );
+  const normalizedServer =
+    serverName && serverName.includes("://") ? serverName : serverName ? `mcp://${serverName}` : "";
+  const tool = firstNonEmpty(src.tool, src.tool_name, src.toolName, src.mcp_tool, parsed?.toolName);
+  const out = {
+    ...src,
+    parameters: buildMcpParameters(src),
+  };
+
+  if (normalizedServer) out.server = normalizedServer;
+  if (tool) out.tool = tool;
+
+  return out;
+}
+
+export function normalizePolicyContext(policyName, toolName, params, event) {
+  if (policyName === "system.command.execute.v1") {
+    return normalizeExecContext(params, event);
+  }
+  if (policyName === "data.file.read.v1" || policyName === "data.file.write.v1") {
+    return normalizeFileContext(params);
+  }
+  if (policyName === "messaging.message.send.v1") {
+    return normalizeMessageContext(params);
+  }
+  if (policyName === "mcp.tool.execute.v1") {
+    return normalizeMcpContext(toolName, params);
+  }
+  return params || {};
 }

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -10,6 +10,14 @@ OpenClaw currently uses the `openclaw-aport` plugin path.
 - Development install: `openclaw plugins install -l /path/to/aport-agent-guardrails/extensions/openclaw-aport`
 - Runtime enforcement: plugin `before_tool_call`
 
+Direct plugin install only installs the plugin bundle. It does not create a passport or write plugin config. Use the public setup command for a complete working setup.
+
+Recommended follow-up after direct install:
+
+```bash
+npx @aporthq/aport-agent-guardrails openclaw
+```
+
 ## Location
 
 - Plugin runtime: [extensions/openclaw-aport](../../extensions/openclaw-aport)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -30,7 +30,7 @@
     },
     "extensions/openclaw-aport": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -15078,7 +15078,7 @@
     },
     "packages/claude-code": {
       "name": "@aporthq/aport-agent-guardrails-claude-code",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15093,7 +15093,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -15112,7 +15112,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15127,7 +15127,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15142,7 +15142,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15159,7 +15159,7 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22",
@@ -15178,7 +15178,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "workspaces": [
     "packages/*",

--- a/packages/claude-code/CHANGELOG.md
+++ b/packages/claude-code/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-claude-code
 
+## 1.0.23
+
+### Patch Changes
+
+- @aporthq/aport-agent-guardrails-core@1.0.23
+
 ## 1.0.22
 
 ### Patch Changes

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-claude-code",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "APort guardrails for Claude Code — PreToolUse hook",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.23"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @aporthq/aport-agent-guardrails-core
 
+## 1.0.23
+
 ## 1.0.22
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crewai/CHANGELOG.md
+++ b/packages/crewai/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-crewai
 
+## 1.0.23
+
+### Patch Changes
+
+- @aporthq/aport-agent-guardrails-core@1.0.23
+
 ## 1.0.22
 
 ### Patch Changes

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.23"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-cursor
 
+## 1.0.23
+
+### Patch Changes
+
+- @aporthq/aport-agent-guardrails-core@1.0.23
+
 ## 1.0.22
 
 ### Patch Changes

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.23"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
   "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
   "main": "index.js",

--- a/packages/langchain/CHANGELOG.md
+++ b/packages/langchain/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-langchain
 
+## 1.0.23
+
+### Patch Changes
+
+- @aporthq/aport-agent-guardrails-core@1.0.23
+
 ## 1.0.22
 
 ### Patch Changes

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.22",
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.23",
     "@langchain/core": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/n8n/CHANGELOG.md
+++ b/packages/n8n/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-n8n
 
+## 1.0.23
+
+### Patch Changes
+
+- @aporthq/aport-agent-guardrails-core@1.0.23
+
 ## 1.0.22
 
 ### Patch Changes

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.23"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/python/aport_guardrails/__init__.py
+++ b/python/aport_guardrails/__init__.py
@@ -3,7 +3,7 @@ aport_guardrails — Core evaluator, passport, and config for APort agent guardr
 Shared across Python framework adapters (LangChain, CrewAI, AutoGen).
 """
 
-__version__ = "1.0.22"
+__version__ = "1.0.23"
 
 from aport_guardrails.core.evaluator import Evaluator, Decision, ToolContext
 from aport_guardrails.core.passport import load_passport, validate_passport

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.22"
+version = "1.0.23"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.22"
+version = "1.0.23"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.22"
+version = "1.0.23"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/extensions/openclaw-aport.test.js
+++ b/tests/extensions/openclaw-aport.test.js
@@ -13,6 +13,11 @@ import plugin, {
   verifyDecisionIntegrity,
 } from "../../extensions/openclaw-aport/index.js";
 import { evaluateLocalDecision } from "../../extensions/openclaw-aport/local-evaluator.js";
+import {
+  normalizeFileContext,
+  normalizeMcpContext,
+  normalizeMessageContext,
+} from "../../extensions/openclaw-aport/tool-mapping.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -90,13 +95,100 @@ describe("verifyDecisionIntegrity", () => {
 });
 
 describe("mapToolToPolicy", () => {
-  it("keeps the existing OpenClaw policy mappings", () => {
+  it("maps current OpenClaw message and MCP tools while dropping speculative mappings", () => {
     assert.strictEqual(mapToolToPolicy("exec.run"), "system.command.execute.v1");
     assert.strictEqual(mapToolToPolicy("git.create_pr"), "code.repository.merge.v1");
-    assert.strictEqual(mapToolToPolicy("message.send"), "messaging.message.send.v1");
+    assert.strictEqual(mapToolToPolicy("message", { action: "send" }), "messaging.message.send.v1");
+    assert.strictEqual(mapToolToPolicy("message", { action: "react" }), "messaging.message.send.v1");
+    assert.strictEqual(mapToolToPolicy("message", { action: "read" }), null);
     assert.strictEqual(mapToolToPolicy("multiedit"), "data.file.write.v1");
     assert.strictEqual(mapToolToPolicy("mcp__github__list"), "mcp.tool.execute.v1");
+    assert.strictEqual(mapToolToPolicy("vigil-harbor__memory_search"), "mcp.tool.execute.v1");
+    assert.strictEqual(mapToolToPolicy("sessions_spawn"), null);
+    assert.strictEqual(mapToolToPolicy("sessions_send"), null);
+    assert.strictEqual(mapToolToPolicy("tool.register"), null);
+    assert.strictEqual(mapToolToPolicy("refund"), null);
+    assert.strictEqual(mapToolToPolicy("export"), null);
     assert.strictEqual(mapToolToPolicy("unknown.tool"), null);
+  });
+});
+
+describe("normalizeFileContext", () => {
+  it("maps OpenClaw path-shaped file params to OAP file_path", () => {
+    assert.deepStrictEqual(normalizeFileContext({ path: "README.md", content: "hi" }), {
+      path: "README.md",
+      file_path: "README.md",
+      content: "hi",
+    });
+    assert.deepStrictEqual(normalizeFileContext({ file_path: "README.md", content: "hi" }), {
+      file_path: "README.md",
+      content: "hi",
+    });
+  });
+});
+
+describe("normalizeMessageContext", () => {
+  it("maps current OpenClaw message params to APort messaging context", () => {
+    assert.deepStrictEqual(
+      normalizeMessageContext({
+        action: "sendAttachment",
+        target: "telegram:group:123",
+        caption: "Invoice attached",
+        filename: "invoice.pdf",
+        threadId: "42",
+        replyTo: "99",
+      }),
+      {
+        action: "sendAttachment",
+        target: "telegram:group:123",
+        caption: "Invoice attached",
+        filename: "invoice.pdf",
+        threadId: "42",
+        replyTo: "99",
+        message_type: "file",
+        channel_id: "telegram:group:123",
+        message: "Invoice attached",
+        thread_id: "42",
+        reply_to: "99",
+        attachments: [{ filename: "invoice.pdf" }],
+      },
+    );
+    assert.deepStrictEqual(
+      normalizeMessageContext({ action: "react", target: "whatsapp:chat:1", emoji: "👍" }),
+      {
+        action: "react",
+        target: "whatsapp:chat:1",
+        emoji: "👍",
+        message_type: "reaction",
+        channel_id: "whatsapp:chat:1",
+        message: "👍",
+      },
+    );
+  });
+});
+
+describe("normalizeMcpContext", () => {
+  it("derives MCP policy context from provider-safe OpenClaw tool names", () => {
+    assert.deepStrictEqual(
+      normalizeMcpContext("vigil-harbor__memory_search", { query: "release notes" }),
+      {
+        query: "release notes",
+        server: "mcp://vigil-harbor",
+        tool: "memory_search",
+        parameters: { query: "release notes" },
+      },
+    );
+    assert.deepStrictEqual(
+      normalizeMcpContext("mcp__github__pull_requests-create", {
+        input: { owner: "aporthq", repo: "aport-agent-guardrails" },
+      }),
+      {
+        input: { owner: "aporthq", repo: "aport-agent-guardrails" },
+        server: "mcp://github",
+        tool: "pull_requests-create",
+        parameters: { owner: "aporthq", repo: "aport-agent-guardrails" },
+      },
+    );
   });
 });
 
@@ -138,6 +230,42 @@ describe("plugin hook contract", () => {
     assert.ok(!Object.prototype.hasOwnProperty.call(denyResult, "reasons"));
 
     await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("normalizes write tool params before API verification", async () => {
+    const originalFetch = globalThis.fetch;
+    let seenBody = null;
+    globalThis.fetch = async (_url, opts) => {
+      seenBody = JSON.parse(String(opts?.body ?? "{}"));
+      return {
+        ok: true,
+        async json() {
+          return {
+            decision: {
+              allow: true,
+              decision_id: "dec-1",
+              reasons: [{ code: "oap.allowed", message: "ok" }],
+              content_hash: `sha256:${createHash("sha256").update(canonicalize({
+                allow: true,
+                decision_id: "dec-1",
+                reasons: [{ code: "oap.allowed", message: "ok" }],
+              }), "utf8").digest("hex")}`,
+            },
+          };
+        },
+      };
+    };
+
+    try {
+      const beforeToolCall = await registerPlugin({ mode: "api", agentId: "ap_test" });
+      const result = await beforeToolCall({ toolName: "write", params: { path: "README.md", content: "hi" } });
+      assert.deepStrictEqual(result, {});
+      assert.ok(seenBody);
+      assert.strictEqual(seenBody.context.file_path, "README.md");
+      assert.strictEqual(seenBody.context.path, "README.md");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/tests/test-remote-passport-api.sh
+++ b/tests/test-remote-passport-api.sh
@@ -3,7 +3,7 @@
 # The API fetches the passport from the registry by agent_id.
 #
 # Usage: ./test-remote-passport-api.sh
-#   Optional: APORT_TEST_REMOTE_AGENT_ID=ap_xxx  (default: ap_8955f5450cd542fe8f67bbbf07c3e103)
+#   Optional: APORT_TEST_REMOTE_AGENT_ID=ap_xxx  (default fallback fixture may skip if its hosted policy drifts)
 #   Optional: APORT_API_URL (default: https://api.aport.io; use http://localhost:8787 for local)
 #   Optional: APORT_API_KEY=... (if API requires auth)
 #
@@ -22,7 +22,12 @@ set -e
 source "$(dirname "$0")/setup.sh"
 
 # Remote passport (hosted) to test — create one at https://aport.io/builder/create
-REMOTE_AGENT_ID="${APORT_TEST_REMOTE_AGENT_ID:-ap_8955f5450cd542fe8f67bbbf07c3e103}"
+DEFAULT_REMOTE_AGENT_ID="ap_28a13d934f594713b98091e83bac14d3"
+REMOTE_AGENT_ID="${APORT_TEST_REMOTE_AGENT_ID:-$DEFAULT_REMOTE_AGENT_ID}"
+USING_DEFAULT_REMOTE_AGENT_ID=""
+if [ -z "${APORT_TEST_REMOTE_AGENT_ID:-}" ]; then
+    USING_DEFAULT_REMOTE_AGENT_ID="1"
+fi
 
 if [ -n "$APORT_SKIP_REMOTE_PASSPORT_TEST" ]; then
     echo "  Skipping remote passport API test (APORT_SKIP_REMOTE_PASSPORT_TEST is set)"
@@ -59,6 +64,16 @@ RESP=$(curl -s --connect-timeout 5 -w "\n%{http_code}" -X POST "${APORT_API_URL%
 if echo "${RESP:-}" | grep -q "passport_not_found\|Passport with the specified agent ID was not found"; then
     echo "  Skipping: No hosted passport for agent $REMOTE_AGENT_ID (create one at aport.io or set APORT_TEST_REMOTE_AGENT_ID)"
     exit 0
+fi
+
+if echo "${RESP:-}" | grep -q "Missing required capabilities: system.command.execute"; then
+    if [ -n "$USING_DEFAULT_REMOTE_AGENT_ID" ]; then
+        echo "  Skipping: default hosted fixture $REMOTE_AGENT_ID no longer allows system.command.execute"
+        echo "  Set APORT_TEST_REMOTE_AGENT_ID to a live hosted passport with that capability to run the full remote smoke test."
+        exit 0
+    fi
+    echo "  ❌ Hosted passport $REMOTE_AGENT_ID is reachable but missing required capability system.command.execute"
+    exit 1
 fi
 
 echo "  Test 1: ALLOW — safe command (e.g. ls)"

--- a/tests/unit/test-openclaw-installer-skip-same-version.sh
+++ b/tests/unit/test-openclaw-installer-skip-same-version.sh
@@ -18,6 +18,7 @@ cat > "$FAKE_BIN/openclaw" << 'SCRIPT'
 #!/bin/bash
 set -e
 LOG_FILE="${APORT_FAKE_OPENCLAW_LOG:?}"
+PLUGIN_VERSION="${APORT_FAKE_OPENCLAW_PLUGIN_VERSION:?}"
 
 if [[ "$1" == "plugins" && "$2" == "list" && "$3" == "--json" ]]; then
   cat <<JSON
@@ -26,7 +27,7 @@ if [[ "$1" == "plugins" && "$2" == "list" && "$3" == "--json" ]]; then
   "plugins": [
     {
       "id": "openclaw-aport",
-      "version": "__PLUGIN_VERSION__"
+      "version": "$PLUGIN_VERSION"
     }
   ]
 }
@@ -58,11 +59,9 @@ fi
 
 exit 0
 SCRIPT
-sed -i '' "s|__PLUGIN_VERSION__|$PLUGIN_VERSION|g" "$FAKE_BIN/openclaw"
-sed -i '' "s|__LOG_FILE__|$LOG_FILE|g" "$FAKE_BIN/openclaw"
 chmod +x "$FAKE_BIN/openclaw"
 
-printf '\n\n\n' | env PATH="$FAKE_BIN:$NODE_DIR:/usr/bin:/bin" OPENCLAW_HOME="$CONFIG_DIR" APORT_FAKE_OPENCLAW_LOG="$LOG_FILE" \
+printf '\n\n\n' | env PATH="$FAKE_BIN:$NODE_DIR:/usr/bin:/bin" OPENCLAW_HOME="$CONFIG_DIR" APORT_FAKE_OPENCLAW_LOG="$LOG_FILE" APORT_FAKE_OPENCLAW_PLUGIN_VERSION="$PLUGIN_VERSION" \
     "$REPO_ROOT/bin/openclaw" "$AGENT_ID" > "$TEST_DIR/stdout.log" 2>&1
 
 if [[ -f "$LOG_FILE" ]] && grep -q "INSTALL_CALLED" "$LOG_FILE"; then

--- a/tests/unit/test-openclaw-installer-skip-same-version.sh
+++ b/tests/unit/test-openclaw-installer-skip-same-version.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Ensure bin/openclaw does not reinstall the plugin when the same version is already installed.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_DIR="${APORT_TEST_DIR:-$(mktemp -d 2> /dev/null || echo "$REPO_ROOT/tests/output")}"
+FAKE_BIN="$TEST_DIR/bin"
+CONFIG_DIR="$TEST_DIR/.openclaw"
+LOG_FILE="$TEST_DIR/openclaw-skip-install.log"
+AGENT_ID="ap_8955f5450cd542fe8f67bbbf07c3e103"
+PLUGIN_VERSION="$(node -e 'const fs=require("node:fs"); const pkg=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(pkg.version);' "$REPO_ROOT/extensions/openclaw-aport/package.json")"
+
+mkdir -p "$FAKE_BIN" "$CONFIG_DIR"
+NODE_DIR="$(dirname "$(command -v node)")"
+
+cat > "$FAKE_BIN/openclaw" << 'SCRIPT'
+#!/bin/bash
+set -e
+LOG_FILE="${APORT_FAKE_OPENCLAW_LOG:?}"
+
+if [[ "$1" == "plugins" && "$2" == "list" && "$3" == "--json" ]]; then
+  cat <<JSON
+[plugins] [APort] Loaded: mode=local, passportFile=/tmp/passport.json, unmapped=allow, mapExec=true
+{
+  "plugins": [
+    {
+      "id": "openclaw-aport",
+      "version": "__PLUGIN_VERSION__"
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "$1" == "plugins" && "$2" == "list" ]]; then
+  echo "openclaw-aport"
+  exit 0
+fi
+
+if [[ "$1" == "plugins" && "$2" == "install" ]]; then
+  echo "INSTALL_CALLED" >> "__LOG_FILE__"
+  exit 99
+fi
+
+if [[ "$1" == "gateway" && "$2" == "restart" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "gateway" && "$2" == "probe" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "gateway" && "$2" == "start" ]]; then
+  exit 0
+fi
+
+exit 0
+SCRIPT
+sed -i '' "s|__PLUGIN_VERSION__|$PLUGIN_VERSION|g" "$FAKE_BIN/openclaw"
+sed -i '' "s|__LOG_FILE__|$LOG_FILE|g" "$FAKE_BIN/openclaw"
+chmod +x "$FAKE_BIN/openclaw"
+
+printf '\n\n\n' | env PATH="$FAKE_BIN:$NODE_DIR:/usr/bin:/bin" OPENCLAW_HOME="$CONFIG_DIR" APORT_FAKE_OPENCLAW_LOG="$LOG_FILE" \
+    "$REPO_ROOT/bin/openclaw" "$AGENT_ID" > "$TEST_DIR/stdout.log" 2>&1
+
+if [[ -f "$LOG_FILE" ]] && grep -q "INSTALL_CALLED" "$LOG_FILE"; then
+    echo "FAIL: expected bin/openclaw to skip reinstall for same plugin version" >&2
+    cat "$TEST_DIR/stdout.log" >&2
+    exit 1
+fi
+
+grep -q "already installed; skipping reinstall" "$TEST_DIR/stdout.log" || {
+    echo "FAIL: expected skip reinstall message" >&2
+    cat "$TEST_DIR/stdout.log" >&2
+    exit 1
+}
+
+if [[ ! -f "$CONFIG_DIR/config.yaml" ]]; then
+    echo "FAIL: expected config.yaml to still be written after skip" >&2
+    cat "$TEST_DIR/stdout.log" >&2
+    exit 1
+fi
+
+echo "  ✅ bin/openclaw skips reinstall when the same plugin version is already installed"


### PR DESCRIPTION
## Summary
- harden the OpenClaw plugin for current public OpenClaw releases
- tighten OpenClaw tool mapping and hosted API context normalization
- skip redundant plugin reinstall when the same plugin version is already installed
- document the bundle-only direct plugin install path and bump the synced suite to 1.0.23

## Details
- map current OpenClaw message actions and provider-safe MCP tool names correctly in the plugin
- remove speculative OpenClaw mappings that did not match the current host tool surface
- normalize file, message, and MCP context before hosted API evaluation
- add regression coverage for the OpenClaw plugin mapping and installer skip behavior
- harden the hosted remote-passport smoke test so default fixtures skip when the hosted passport drifts

## Verification
- `npm run prepush:check`
- full repo shell/integration suite: `All 36 tests passed`
- OpenClaw plugin tests passed
- Python package build/install smoke passed
- CrewAI and LangChain E2E passed
- Python core tests: `72 passed`