### PR TITLE
Release 1.0.25 updates guardrail mode handling and release reliability.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official APort plugins — security guardrails for AI coding agents",
-    "version": "1.0.24",
+    "version": "1.0.25",
     "license": "Apache-2.0",
     "homepage": "https://aport.io"
   },
@@ -17,7 +17,7 @@
       "source": {
         "source": "github",
         "repo": "aporthq/aport-agent-guardrails",
-        "ref": "v1.0.24"
+        "ref": "v1.0.25"
       },
       "keywords": [
         "security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aport-guardrails",
   "description": "APort Agent Guardrails — security policy enforcement for every tool call. Intercepts tool use, evaluates against your passport policy, and blocks unauthorized actions.",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "author": {
     "name": "APort Technologies Inc.",
     "email": "hello@aport.io",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,23 +86,52 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # npm registry CDN can briefly lag behind a successful publish; retry before failing CI.
       - name: Verify npm publication
         run: |
-          set -euo pipefail
+          set -uo pipefail
           VERSION="${{ steps.version.outputs.VERSION }}"
-          for pkg in \
-            @aporthq/aport-agent-guardrails \
-            @aporthq/aport-agent-guardrails-core \
-            @aporthq/aport-agent-guardrails-langchain \
-            @aporthq/aport-agent-guardrails-crewai \
-            @aporthq/aport-agent-guardrails-cursor \
-            @aporthq/aport-agent-guardrails-claude-code \
-            @aporthq/openclaw-aport \
-            @aporthq/agent-guardrails; do
-            echo "Verifying ${pkg}@${VERSION} on npm..."
-            npm view "${pkg}@${VERSION}" version --registry https://registry.npmjs.org/ >/dev/null
+          PACKAGES=(
+            "@aporthq/aport-agent-guardrails"
+            "@aporthq/aport-agent-guardrails-core"
+            "@aporthq/aport-agent-guardrails-langchain"
+            "@aporthq/aport-agent-guardrails-crewai"
+            "@aporthq/aport-agent-guardrails-cursor"
+            "@aporthq/aport-agent-guardrails-claude-code"
+            "@aporthq/openclaw-aport"
+            "@aporthq/agent-guardrails"
+          )
+          MAX_ATTEMPTS="4"
+          SLEEP_SECONDS="25"
+
+          verify_all() {
+            local failed=0
+            for pkg in "${PACKAGES[@]}"; do
+              echo "  Checking ${pkg}@${VERSION}"
+              if ! npm view "${pkg}@${VERSION}" version --registry https://registry.npmjs.org/ >/dev/null 2>&1; then
+                failed=1
+              fi
+            done
+            return "$failed"
+          }
+
+          for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+            echo "npm verify (${attempt}/${MAX_ATTEMPTS})..."
+            set +e
+            verify_all
+            rc=$?
+            set -e
+            if [[ "$rc" -eq 0 ]]; then
+              echo "npm publication OK"
+              exit 0
+            fi
+            if [[ "$attempt" -lt "${MAX_ATTEMPTS}" ]]; then
+              echo "registry not consistent yet; waiting ${SLEEP_SECONDS}s..."
+              sleep "${SLEEP_SECONDS}"
+            fi
           done
-          echo "npm publication OK"
+          echo "::error::npm verification failed after ${MAX_ATTEMPTS} attempts (${SLEEP_SECONDS}s between retries)"
+          exit 1
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -156,25 +185,38 @@ jobs:
           python -m twine upload --skip-existing python/langchain_adapter/dist/*
           python -m twine upload --skip-existing python/crewai_adapter/dist/*
 
+      # Simple index can lag briefly after twine upload succeeds; retry before failing CI.
       - name: Verify PyPI publication
         run: |
+          set -uo pipefail
           export VERSION="${{ steps.version.outputs.VERSION }}"
-          for pkg in aport-agent-guardrails aport-agent-guardrails-langchain aport-agent-guardrails-crewai; do
-            echo "Verifying $pkg@$VERSION on PyPI..."
-            export PKG="$pkg"
-            python -c "
-          import urllib.request, json, sys, os
-          v = os.environ.get('VERSION', '')
-          p = os.environ.get('PKG', '')
-          req = urllib.request.Request(f'https://pypi.org/pypi/{p}/json')
-          with urllib.request.urlopen(req) as r:
-              data = json.loads(r.read().decode())
-          if v in data.get('releases', {}):
-              print(f'OK: {p}@{v} published')
-          else:
-              sys.exit(f'Version {v} not found for {p}')
-          "
+          MAX_ATTEMPTS="4"
+          SLEEP_SECONDS="25"
+
+          verify_py() {
+            local pkg
+            for pkg in aport-agent-guardrails aport-agent-guardrails-langchain aport-agent-guardrails-crewai; do
+              PKG="$pkg" VERSION="$VERSION" python -c "import json, os, urllib.request as u, sys; v=os.environ['VERSION']; p=os.environ['PKG']; d=json.loads(u.urlopen('https://pypi.org/pypi/'+p+'/json').read().decode()); sys.exit(0 if v in d.get('releases',{}) else 1)"
+            done
+          }
+
+          for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+            echo "PyPI verify (${attempt}/${MAX_ATTEMPTS})..."
+            set +e
+            verify_py
+            rc=$?
+            set -e
+            if [[ "$rc" -eq 0 ]]; then
+              echo "PyPI publication OK"
+              exit 0
+            fi
+            if [[ "$attempt" -lt "${MAX_ATTEMPTS}" ]]; then
+              echo "index not listing version yet; waiting ${SLEEP_SECONDS}s..."
+              sleep "${SLEEP_SECONDS}"
+            fi
           done
+          echo "::error::PyPI verification failed after ${MAX_ATTEMPTS} attempts (${SLEEP_SECONDS}s between retries)"
+          exit 1
 
   create-release:
     needs: [publish-npm, publish-python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.25] - 2026-05-05
+
+### Fixed
+- **Hosted API mode in hooks:** `load_guardrail_mode_for_hooks` uses `set -a` / `set +a` while sourcing `guardrail-mode.env` so `APORT_GUARDRAIL_MODE`, `APORT_API_URL`, `APORT_AGENT_ID`, etc. are **exported** to child guardrail processes (hosted API verification).
+
+### Changed
+- **Release workflow:** npm and PyPI verification steps retry (4 attempts, 25s between tries) after publish so transient registry/CDN lag does not fail the job.
+
+### Added
+- **Tests:** Unit coverage ensuring guardrail-mode env values are exported after loading from disk.
+
 ## [1.0.24] - 2026-04-29
 
 ### Added

--- a/bin/lib/guardrail-mode.sh
+++ b/bin/lib/guardrail-mode.sh
@@ -148,7 +148,9 @@ load_guardrail_mode_for_hooks() {
     local config_dir="$1"
     local mode_file="$config_dir/aport/guardrail-mode.env"
     if [[ -f "$mode_file" ]]; then
+        set -a
         # shellcheck disable=SC1090
         source "$mode_file"
+        set +a
     fi
 }

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release process and version policy
 
-**Current release:** 1.0.24 (see [CHANGELOG.md](../CHANGELOG.md)).
+**Current release:** 1.0.25 (see [CHANGELOG.md](../CHANGELOG.md)).
 
 We keep **one version number** across all published packages (Node core, Python core, and every framework adapter). That avoids “core is 1.2 but CLI is 0.9” and keeps the story simple for users and support.
 

--- a/extensions/openclaw-aport/CHANGELOG.md
+++ b/extensions/openclaw-aport/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog - APort OpenClaw Plugin
 
+## 1.0.25
+
 ## 1.0.24
 
 ## 1.0.23

--- a/extensions/openclaw-aport/openclaw.plugin.json
+++ b/extensions/openclaw-aport/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclaw-aport",
   "name": "APort Guardrails",
   "description": "Deterministic pre-action authorization via APort policy enforcement. Registers before_tool_call to block disallowed tools.",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/openclaw-aport/package-lock.json
+++ b/extensions/openclaw-aport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -30,7 +30,7 @@
     },
     "extensions/openclaw-aport": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -15078,7 +15078,7 @@
     },
     "packages/claude-code": {
       "name": "@aporthq/aport-agent-guardrails-claude-code",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15093,7 +15093,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -15112,7 +15112,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15127,7 +15127,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15142,7 +15142,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15159,7 +15159,7 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22",
@@ -15178,7 +15178,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "workspaces": [
     "packages/*",

--- a/packages/claude-code/CHANGELOG.md
+++ b/packages/claude-code/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-claude-code
 
+## 1.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.25
+
 ## 1.0.24
 
 ### Patch Changes

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-claude-code",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "APort guardrails for Claude Code — PreToolUse hook",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.24"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-core
 
+## 1.0.25
+
+### Patch Changes
+
+- Release 1.0.25: export guardrail-mode env for API child processes; release workflow verify retries.
+
 ## 1.0.24
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crewai/CHANGELOG.md
+++ b/packages/crewai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-crewai
 
+## 1.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.25
+
 ## 1.0.24
 
 ### Patch Changes

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.24"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-cursor
 
+## 1.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.25
+
 ## 1.0.24
 
 ### Patch Changes

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.24"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
   "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
   "main": "index.js",

--- a/packages/langchain/CHANGELOG.md
+++ b/packages/langchain/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-langchain
 
+## 1.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.25
+
 ## 1.0.24
 
 ### Patch Changes

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.24",
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.25",
     "@langchain/core": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/n8n/CHANGELOG.md
+++ b/packages/n8n/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-n8n
 
+## 1.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.25
+
 ## 1.0.24
 
 ### Patch Changes

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.24"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/python/aport_guardrails/__init__.py
+++ b/python/aport_guardrails/__init__.py
@@ -3,7 +3,7 @@ aport_guardrails — Core evaluator, passport, and config for APort agent guardr
 Shared across Python framework adapters (LangChain, CrewAI, AutoGen).
 """
 
-__version__ = "1.0.24"
+__version__ = "1.0.25"
 
 from aport_guardrails.core.evaluator import Evaluator, Decision, ToolContext
 from aport_guardrails.core.passport import load_passport, validate_passport

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.24"
+version = "1.0.25"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.24"
+version = "1.0.25"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.24"
+version = "1.0.25"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/unit/test-guardrail-mode-env-export.sh
+++ b/tests/unit/test-guardrail-mode-env-export.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Unit test: guardrail mode loaded from disk must be exported so child guardrail
+# processes receive hosted-mode settings like APORT_AGENT_ID.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$(dirname "$0")/../setup.sh"
+source "$REPO_ROOT/bin/lib/guardrail-mode.sh"
+
+mkdir -p "$TEST_DIR/aport"
+MODE_FILE="$TEST_DIR/aport/guardrail-mode.env"
+
+cat > "$MODE_FILE" << 'EOF'
+APORT_GUARDRAIL_MODE=api
+APORT_API_URL=https://api.aport.io
+APORT_AGENT_ID=ap_04c65c1dd7224160b36b756960e2cc48
+EOF
+
+unset APORT_GUARDRAIL_MODE APORT_API_URL APORT_AGENT_ID 2> /dev/null || true
+
+load_guardrail_mode_for_hooks "$TEST_DIR"
+
+[ "$APORT_GUARDRAIL_MODE" = "api" ] || {
+    echo "FAIL: expected APORT_GUARDRAIL_MODE=api in current shell, got '${APORT_GUARDRAIL_MODE:-}'" >&2
+    exit 1
+}
+
+[ "$APORT_API_URL" = "https://api.aport.io" ] || {
+    echo "FAIL: expected APORT_API_URL in current shell, got '${APORT_API_URL:-}'" >&2
+    exit 1
+}
+
+[ "$APORT_AGENT_ID" = "ap_04c65c1dd7224160b36b756960e2cc48" ] || {
+    echo "FAIL: expected APORT_AGENT_ID in current shell, got '${APORT_AGENT_ID:-}'" >&2
+    exit 1
+}
+
+bash -c '
+    [ "${APORT_GUARDRAIL_MODE:-}" = "api" ] &&
+    [ "${APORT_API_URL:-}" = "https://api.aport.io" ] &&
+    [ "${APORT_AGENT_ID:-}" = "ap_04c65c1dd7224160b36b756960e2cc48" ]
+' || {
+    echo "FAIL: hosted guardrail mode variables were not exported to child process" >&2
+    exit 1
+}
+
+echo "OK test-guardrail-mode-env-export.sh"


### PR DESCRIPTION
## Description

- Export env vars loaded from `guardrail-mode.env` (`set -a` / `set +a`) so child guardrail processes in hosted API mode receive `APORT_GUARDRAIL_MODE`, `APORT_API_URL`, and `APORT_AGENT_ID`.
- Add retry/backoff to release verification in `.github/workflows/release.yml` for npm and PyPI propagation lag (4 attempts, 25s interval).
- Add unit coverage for env export behavior from guardrail mode file.
- Run version sync to 1.0.25 across npm workspaces, Python packages, extension manifests, release docs, and changelogs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Policy pack addition
- [x] Documentation update
- [x] Other: release/version sync

## Testing

- [x] Tests pass locally
- [x] Manual testing completed
- [x] Documentation updated

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests added/updated

## Related Issues
-