### PR TITLE
Release: 1.0.26 framework reset and CI hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official APort plugins — security guardrails for AI coding agents",
-    "version": "1.0.25",
+    "version": "1.0.26",
     "license": "Apache-2.0",
     "homepage": "https://aport.io"
   },
@@ -17,7 +17,7 @@
       "source": {
         "source": "github",
         "repo": "aporthq/aport-agent-guardrails",
-        "ref": "v1.0.25"
+        "ref": "v1.0.26"
       },
       "keywords": [
         "security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aport-guardrails",
   "description": "APort Agent Guardrails — security policy enforcement for every tool call. Intercepts tool use, evaluates against your passport policy, and blocks unauthorized actions.",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "author": {
     "name": "APort Technologies Inc.",
     "email": "hello@aport.io",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq uuid-runtime
+          set -euo pipefail
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update
+          sudo apt-get install -y --no-install-recommends jq uuid-runtime
       
       - name: Make scripts executable
         run: |
@@ -47,6 +48,9 @@ jobs:
 
       - name: Install Node dependencies
         run: npm ci
+
+      - name: Verify npm dependency signatures
+        run: npm audit signatures
 
       - name: Build and test Node packages
         run: |

--- a/.github/workflows/e2e-crewai.yml
+++ b/.github/workflows/e2e-crewai.yml
@@ -23,8 +23,10 @@ jobs:
 
       - name: Install core and crewai adapter (editable)
         run: |
-          pip install -e python/aport_guardrails -e "python/crewai_adapter[dev]"
-          pip install "crewai>=0.80"
+          python -m pip install --upgrade pip
+          pip install --disable-pip-version-check --no-input -e python/aport_guardrails -e "python/crewai_adapter[dev]"
+          pip install --disable-pip-version-check --no-input "crewai>=0.80"
+          python -m pip check
 
       - name: aport-crewai --ci (setup)
         run: |

--- a/.github/workflows/e2e-langchain.yml
+++ b/.github/workflows/e2e-langchain.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Install core and langchain adapter (editable)
         run: |
-          pip install -e python/aport_guardrails -e "python/langchain_adapter[dev]"
+          python -m pip install --upgrade pip
+          pip install --disable-pip-version-check --no-input -e python/aport_guardrails -e "python/langchain_adapter[dev]"
+          python -m pip check
 
       - name: aport-langchain --ci (setup)
         run: |
@@ -58,5 +60,6 @@ jobs:
       - name: Run pytest (core frameworks/langchain)
         run: |
           cd python/aport_guardrails
-          pip install pytest pytest-asyncio -q
+          pip install --disable-pip-version-check --no-input pytest pytest-asyncio -q
+          python -m pip check
           pytest tests/ -v --tb=short

--- a/.github/workflows/e2e-openclaw.yml
+++ b/.github/workflows/e2e-openclaw.yml
@@ -19,8 +19,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq uuid-runtime
+          set -euo pipefail
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update
+          sudo apt-get install -y --no-install-recommends jq uuid-runtime
 
       - name: Make scripts executable
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify npm dependency signatures
+        run: npm audit signatures
+
       - name: Verify version matches release version
         run: |
           TAG_VERSION="${{ steps.version.outputs.VERSION }}"
@@ -162,7 +165,10 @@ jobs:
           python-version: "3.10"
 
       - name: Install build tools
-        run: pip install build twine
+        run: |
+          python -m pip install --upgrade pip
+          pip install --disable-pip-version-check --no-input build twine
+          python -m pip check
 
       - name: Build Python packages (core + adapters)
         run: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Install shfmt
         run: |
-          curl -sSL "https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64" -o /tmp/shfmt
-          chmod +x /tmp/shfmt
-          sudo mv /tmp/shfmt /usr/local/bin/shfmt
+          set -euo pipefail
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 update
+          sudo apt-get install -y --no-install-recommends shfmt
           shfmt --version
 
       - name: Check shell script formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.26] - 2026-05-05
+
+### Added
+- **Framework reset command:** Added `agent-guardrails reset <framework>` with `bin/aport-reset-framework.sh` to remove APort-managed hook/config artifacts safely while preserving user custom hooks where applicable.
+- **Tests:** Added `tests/unit/test-framework-reset.sh` coverage for framework reset behavior and dispatcher reset routing.
+
+### Changed
+- **CI hardening:** Workflow install steps now use safer/reliable defaults (`apt` retries+timeouts, `--no-install-recommends`, pip non-interactive flags).
+- **Release/dependency verification:** Added npm signature verification (`npm audit signatures`) and dependency consistency checks (`pip check`) in CI/release pipelines.
+
 ## [1.0.25] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npx @aporthq/aport-agent-guardrails
 - Choose your framework: `openclaw`, `cursor`, `claude-code`, `langchain`, `crewai`, `deerflow`, `n8n`
 - OpenClaw direct: `npx @aporthq/aport-agent-guardrails openclaw`
 - Hosted passport: `npx @aporthq/aport-agent-guardrails openclaw <agent_id>`
+- Reset a framework to a clean APort state: `npx @aporthq/aport-agent-guardrails reset claude-code --yes`
 
 ### Why Developers and teams trust APort
 
@@ -129,6 +130,22 @@ npx @aporthq/aport-agent-guardrails
 #   --mode=local
 ```
 
+**Reset / uninstall APort-owned wiring**
+
+Use the same dispatcher for cleanup:
+
+```bash
+npx @aporthq/aport-agent-guardrails reset claude-code --yes
+# or
+npx @aporthq/aport-agent-guardrails claude-code reset --yes
+```
+
+Supported reset targets match the CLI-supported frameworks:
+`openclaw`, `cursor`, `claude-code`, `langchain`, `crewai`, `deerflow`, `n8n`.
+
+Reset removes APort-owned config and integration wiring for the selected framework.
+When possible, unrelated user hooks are preserved.
+
 **Python (LangChain, CrewAI, or DeerFlow):** Use the Python CLI directly via `uvx` or an installed package:
 ```bash
 uvx --from aport-agent-guardrails aport setup --framework=langchain
@@ -183,7 +200,7 @@ Your framework doc (Cursor, OpenClaw, LangChain, CrewAI) describes where the con
 | **Bypass risk** | None | High |
 | **Recommended** | **Yes** | Only if plugin unavailable |
 
-**Plugin (recommended):** Platform runs the guardrail before every tool; the model cannot skip it. This repo implements the **plugin (before_tool_call)** integration—Option 2 in the [APort × OpenClaw integration proposal](https://github.com/aporthq/agent-passport/tree/main/_plan/execution/openclaw).  
+**Plugin (recommended):** Platform runs the guardrail before every tool; the model cannot skip it. This repo implements the public **plugin (before_tool_call)** integration for OpenClaw.
 **AGENTS.md:** Agent is *instructed* to call the guardrail; best-effort only.
 
 ---
@@ -405,6 +422,7 @@ See [Verification methods](docs/VERIFICATION_METHODS.md) for a detailed comparis
 | Command | Purpose |
 |--------|---------|
 | `agent-guardrails` | Main entry — prompt for framework or pass one: `agent-guardrails openclaw \| cursor \| claude-code \| langchain \| crewai \| deerflow \| n8n`. Args after the framework are passed through (e.g. `agent-guardrails openclaw <agent_id>`). |
+| `agent-guardrails reset <framework> [--yes]` | Remove APort-owned config and hook/plugin wiring for one framework. Positional form also works: `agent-guardrails <framework> reset --yes`. |
 | `aport` | OpenClaw one-command setup (passport + plugin + wrappers). Optional: `aport <agent_id>` for hosted passport. |
 | `aport-guardrail` | Run guardrail check from the CLI (e.g. `aport-guardrail system.command.execute '{"command":"ls"}'`). Uses passport from your framework config dir. |
 
@@ -517,7 +535,7 @@ Contributions welcome: policy packs, framework adapters, docs. See [CONTRIBUTING
 
 Apache 2.0 — see [LICENSE](LICENSE).
 
-**Open-core:** Local evaluation and CLI in this repo are open source (Apache 2.0). [api.aport.io](https://api.aport.io) is a separate product for cloud features (signed receipts, global kill switch, team sync). See [APort × OpenClaw proposal](https://github.com/aporthq/agent-passport/tree/main/_plan/execution/openclaw) for free vs. paid tiers.
+**Open-core:** Local evaluation and CLI in this repo are open source (Apache 2.0). [api.aport.io](https://api.aport.io) is a separate product for cloud features such as signed receipts, global kill switch, and team sync.
 
 ---
 
@@ -527,5 +545,3 @@ Apache 2.0 — see [LICENSE](LICENSE).
 - [GitHub Issues](https://github.com/aporthq/aport-agent-guardrails/issues) · [Discussions](https://github.com/aporthq/aport-agent-guardrails/discussions)
 
 ---
-
-<p align="center">Made with ❤️ by [Uchi](https://github.com/uchibeke/) </p>

--- a/bin/agent-guardrails
+++ b/bin/agent-guardrails
@@ -29,6 +29,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FRAMEWORKS_DIR="$SCRIPT_DIR/frameworks"
 LIB_DIR="$SCRIPT_DIR/lib"
 SUPPORTED_FRAMEWORKS=(openclaw langchain crewai cursor claude-code deerflow n8n)
+reset_requested=""
 
 framework_supported() {
   local candidate="${1:-}"
@@ -44,6 +45,7 @@ framework_supported() {
 # Parse --framework= and -f (skip detection when set)
 framework=""
 integration_mode=""
+noninteractive_requested=""
 REST=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -73,6 +75,10 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       ;;
+    --non-interactive|--noninteractive)
+      noninteractive_requested="1"
+      shift
+      ;;
     *)
       REST+=("$1")
       shift
@@ -80,7 +86,23 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -n "$noninteractive_requested" ]]; then
+  export APORT_NONINTERACTIVE=1
+fi
+
 # If no framework from args, check if first REST argument is a framework name
+if [[ -z "$framework" ]] && [[ ${#REST[@]} -gt 0 ]]; then
+  first_arg="${REST[0]}"
+  if [[ "$first_arg" == "reset" ]] && [[ ${#REST[@]} -gt 1 ]]; then
+    second_arg="${REST[1]}"
+    if framework_supported "$second_arg"; then
+      framework="$second_arg"
+      reset_requested="1"
+      REST=("${REST[@]:2}")
+    fi
+  fi
+fi
+
 if [[ -z "$framework" ]] && [[ ${#REST[@]} -gt 0 ]]; then
   first_arg="${REST[0]}"
   # Check if first arg looks like a framework name (lowercase alphanumeric + hyphen)
@@ -91,6 +113,11 @@ if [[ -z "$framework" ]] && [[ ${#REST[@]} -gt 0 ]]; then
       REST=("${REST[@]:1}")
     fi
   fi
+fi
+
+if [[ -n "$framework" ]] && [[ ${#REST[@]} -gt 0 ]] && [[ "${REST[0]}" == "reset" ]]; then
+  reset_requested="1"
+  REST=("${REST[@]:1}")
 fi
 
 # If still no framework from args, try APORT_FRAMEWORK (non-interactive) or detection
@@ -164,6 +191,15 @@ if ! framework_supported "$framework"; then
 fi
 
 echo "[aport] Selected framework: $framework" >&2
+
+if [[ -n "$reset_requested" ]]; then
+  reset_script="$SCRIPT_DIR/aport-reset-framework.sh"
+  if [[ ! -x "$reset_script" ]]; then
+    echo "[aport] ERROR: Reset helper not found: $reset_script" >&2
+    exit 1
+  fi
+  exec "$reset_script" "$framework" ${REST+"${REST[@]}"}
+fi
 
 if [[ -n "$integration_mode" ]]; then
   case "$integration_mode" in

--- a/bin/aport-reset-framework.sh
+++ b/bin/aport-reset-framework.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]:-.}")/lib" && pwd)"
+# shellcheck source=./lib/common.sh
+source "$LIB/common.sh"
+# shellcheck source=./lib/config.sh
+source "$LIB/config.sh"
+
+framework="${1:-}"
+shift || true
+
+if [[ -z "$framework" ]]; then
+    log_error "Usage: agent-guardrails reset <framework> [--yes]"
+    exit 1
+fi
+
+yes_mode="${APORT_NONINTERACTIVE:-${CI:-}}"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --yes | -y)
+            yes_mode=1
+            ;;
+        *)
+            log_error "Unknown reset option: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+framework="$(echo "$framework" | tr '[:upper:]' '[:lower:]')"
+config_dir="$(get_config_dir "$framework")"
+config_dir="${config_dir/#\~/$HOME}"
+
+confirm_reset() {
+    if [[ -n "$yes_mode" ]]; then
+        return 0
+    fi
+
+    echo ""
+    echo "  Reset APort for $framework"
+    echo "  ──────────────────────────"
+    echo "  This removes APort-owned local config and hook/plugin wiring for this framework."
+    echo "  Other framework settings are preserved when possible."
+    echo ""
+
+    local answer
+    read -r -p "  Continue? [y/N]: " answer
+    case "$answer" in
+        y | Y | yes | YES) ;;
+        *)
+            echo "  Reset cancelled."
+            exit 0
+            ;;
+    esac
+}
+
+backup_file() {
+    local file="$1"
+    if [[ -f "$file" ]]; then
+        cp "$file" "${file}.bak"
+    fi
+}
+
+remove_dir_if_exists() {
+    local dir="$1"
+    if [[ -d "$dir" ]]; then
+        rm -rf "$dir"
+        echo "  ✅ Removed $dir"
+    fi
+}
+
+remove_file_if_exists() {
+    local file="$1"
+    if [[ -f "$file" ]]; then
+        rm -f "$file"
+        echo "  ✅ Removed $file"
+    fi
+}
+
+cleanup_claude_settings() {
+    local settings_file="$1"
+    if [[ ! -f "$settings_file" ]]; then
+        return 0
+    fi
+    if ! command -v jq &> /dev/null; then
+        log_warn "jq not found; leaving Claude settings intact at $settings_file"
+        return 0
+    fi
+
+    local tmpfile
+    tmpfile="$(mktemp "${settings_file}.XXXXXX")"
+    if jq '
+        if (.hooks.PreToolUse? // null) == null then
+            .
+        else
+            .hooks.PreToolUse = (
+                (.hooks.PreToolUse // [])
+                | map(
+                    if (.hooks? // null) == null then
+                        .
+                    else
+                        .hooks = (
+                            (.hooks // [])
+                            | map(select((((.command // "") | test("aport-(cursor-hook|claude-code-hook)\\.sh$")) | not)))
+                        )
+                    end
+                )
+                | map(select(((.hooks? // []) | length) > 0))
+            )
+            | if ((.hooks.PreToolUse // []) | length) == 0 then del(.hooks.PreToolUse) else . end
+            | if ((.hooks // {}) | keys | length) == 0 then del(.hooks) else . end
+        end
+    ' "$settings_file" > "$tmpfile"; then
+        backup_file "$settings_file"
+        mv "$tmpfile" "$settings_file"
+        echo "  ✅ Removed APort Claude Code hook entries from $settings_file"
+    else
+        rm -f "$tmpfile"
+        log_warn "Failed to clean Claude settings at $settings_file"
+    fi
+}
+
+cleanup_cursor_hooks() {
+    local hooks_file="$1"
+    if [[ ! -f "$hooks_file" ]]; then
+        return 0
+    fi
+    if ! command -v jq &> /dev/null; then
+        log_warn "jq not found; leaving Cursor hooks intact at $hooks_file"
+        return 0
+    fi
+
+    local tmpfile
+    tmpfile="$(mktemp "${hooks_file}.XXXXXX")"
+    if jq '
+        def strip_aport_hooks:
+            (. // []) | map(select((((.command // "") | test("aport-(cursor-hook|claude-code-hook)\\.sh$")) | not)));
+        .hooks.beforeShellExecution = ((.hooks.beforeShellExecution // []) | strip_aport_hooks) |
+        .hooks.preToolUse = ((.hooks.preToolUse // []) | strip_aport_hooks) |
+        .hooks.beforeMCPExecution = ((.hooks.beforeMCPExecution // []) | strip_aport_hooks) |
+        .hooks.subagentStart = ((.hooks.subagentStart // []) | strip_aport_hooks) |
+        if ((.hooks.beforeShellExecution // []) | length) == 0 then del(.hooks.beforeShellExecution) else . end |
+        if ((.hooks.preToolUse // []) | length) == 0 then del(.hooks.preToolUse) else . end |
+        if ((.hooks.beforeMCPExecution // []) | length) == 0 then del(.hooks.beforeMCPExecution) else . end |
+        if ((.hooks.subagentStart // []) | length) == 0 then del(.hooks.subagentStart) else . end |
+        if ((.hooks // {}) | keys | length) == 0 then del(.hooks) else . end
+    ' "$hooks_file" > "$tmpfile"; then
+        backup_file "$hooks_file"
+        mv "$tmpfile" "$hooks_file"
+        echo "  ✅ Removed APort Cursor hook entries from $hooks_file"
+    else
+        rm -f "$tmpfile"
+        log_warn "Failed to clean Cursor hooks at $hooks_file"
+    fi
+}
+
+cleanup_openclaw_json() {
+    local openclaw_json="$1"
+    if [[ ! -f "$openclaw_json" ]]; then
+        return 0
+    fi
+    if ! command -v jq &> /dev/null; then
+        log_warn "jq not found; leaving OpenClaw JSON config intact at $openclaw_json"
+        return 0
+    fi
+
+    local tmpfile
+    tmpfile="$(mktemp "${openclaw_json}.XXXXXX")"
+    if jq '
+        .plugins = (.plugins // {}) |
+        .plugins.entries = ((.plugins.entries // {}) | del(.["openclaw-aport"])) |
+        .plugins.installs = ((.plugins.installs // {}) | del(.["openclaw-aport"])) |
+        .plugins.load = (.plugins.load // {}) |
+        .plugins.load.paths = ((.plugins.load.paths // []) | map(select((type == "string" and contains("/openclaw-aport")) | not))) |
+        if ((.plugins.entries // {}) | keys | length) == 0 then del(.plugins.entries) else . end |
+        if ((.plugins.installs // {}) | keys | length) == 0 then del(.plugins.installs) else . end |
+        if ((.plugins.load.paths // []) | length) == 0 then del(.plugins.load.paths) else . end |
+        if ((.plugins.load // {}) | keys | length) == 0 then del(.plugins.load) else . end |
+        if ((.plugins // {}) | keys | length) == 0 then del(.plugins) else . end
+    ' "$openclaw_json" > "$tmpfile"; then
+        backup_file "$openclaw_json"
+        mv "$tmpfile" "$openclaw_json"
+        echo "  ✅ Removed APort OpenClaw entries from $openclaw_json"
+    else
+        rm -f "$tmpfile"
+        log_warn "Failed to clean OpenClaw JSON config at $openclaw_json"
+    fi
+}
+
+cleanup_python_framework() {
+    local config_dir="$1"
+    remove_dir_if_exists "$config_dir/aport"
+    remove_file_if_exists "$config_dir/config.yaml"
+}
+
+cleanup_n8n() {
+    local config_dir="$1"
+    remove_dir_if_exists "$config_dir/aport"
+}
+
+cleanup_claude() {
+    local settings_file="$config_dir/settings.json"
+    remove_dir_if_exists "$config_dir/aport"
+    cleanup_claude_settings "$settings_file"
+}
+
+cleanup_cursor() {
+    local hooks_file="$config_dir/hooks.json"
+    remove_dir_if_exists "$config_dir/aport"
+    cleanup_cursor_hooks "$hooks_file"
+}
+
+cleanup_openclaw() {
+    local openclaw_json="$config_dir/openclaw.json"
+    remove_dir_if_exists "$config_dir/aport"
+    remove_dir_if_exists "$config_dir/extensions/openclaw-aport"
+    remove_dir_if_exists "$config_dir/skills/aport-guardrail"
+    remove_file_if_exists "$config_dir/.aport-repo"
+    remove_file_if_exists "$config_dir/.skills/aport-guardrail.sh"
+    remove_file_if_exists "$config_dir/.skills/aport-guardrail-bash.sh"
+    remove_file_if_exists "$config_dir/.skills/aport-guardrail-api.sh"
+    remove_file_if_exists "$config_dir/.skills/aport-guardrail-v2.sh"
+    remove_file_if_exists "$config_dir/.skills/aport-create-passport.sh"
+    remove_file_if_exists "$config_dir/.skills/aport-status.sh"
+    cleanup_openclaw_json "$openclaw_json"
+    if [[ -f "$config_dir/config.yaml" ]]; then
+        log_warn "OpenClaw config.yaml may still contain APort plugin config. Review $config_dir/config.yaml if you need a completely pristine OpenClaw config."
+    fi
+}
+
+confirm_reset
+
+echo "[aport] Resetting framework: $framework" >&2
+
+case "$framework" in
+    claude-code)
+        cleanup_claude
+        ;;
+    cursor)
+        cleanup_cursor
+        ;;
+    openclaw)
+        cleanup_openclaw
+        ;;
+    langchain | crewai | deerflow)
+        cleanup_python_framework "$config_dir"
+        ;;
+    n8n)
+        cleanup_n8n "$config_dir"
+        ;;
+    *)
+        log_error "Unsupported framework reset: $framework"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "  Reset complete for $framework."
+echo "  Re-run the setup command when you want a fresh install."
+echo ""

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release process and version policy
 
-**Current release:** 1.0.25 (see [CHANGELOG.md](../CHANGELOG.md)).
+**Current release:** 1.0.26 (see [CHANGELOG.md](../CHANGELOG.md)).
 
 We keep **one version number** across all published packages (Node core, Python core, and every framework adapter). That avoids “core is 1.2 but CLI is 0.9” and keeps the story simple for users and support.
 

--- a/docs/frameworks/claude-code.md
+++ b/docs/frameworks/claude-code.md
@@ -24,6 +24,28 @@ npx @aporthq/aport-agent-guardrails --framework=claude-code
 
 This runs the **passport wizard** and writes **`~/.claude/settings.json`** with the APort hook registered for **all tools** via `"matcher": "*"`. Default passport path: **`~/.claude/aport/passport.json`**. Restart Claude Code after setup so the PreToolUse hook is picked up.
 
+If you already have a hosted passport and API key, the intended hosted install path is:
+
+```bash
+export APORT_API_KEY="apk_..."
+export APORT_AGENT_ID="ap_..."
+npx @aporthq/aport-agent-guardrails claude-code "ap_..." --non-interactive
+```
+
+That setup writes `~/.claude/aport/guardrail-mode.env`, and the Claude hook loads those values before every tool call. Hosted mode is fail-closed: if the API evaluator is unreachable, the tool call is denied rather than silently downgraded to local mode.
+
+## Reset / uninstall
+
+To remove APort-owned Claude hook wiring and local config:
+
+```bash
+npx @aporthq/aport-agent-guardrails reset claude-code --yes
+# or
+npx @aporthq/aport-agent-guardrails claude-code reset --yes
+```
+
+This removes `~/.claude/aport/` and strips APort hook entries from `~/.claude/settings.json` while preserving unrelated Claude hooks where possible.
+
 ### Marketplace install (Claude plugins)
 
 APort now includes a Claude plugin marketplace catalog at `.claude-plugin/marketplace.json`.

--- a/extensions/openclaw-aport/CHANGELOG.md
+++ b/extensions/openclaw-aport/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog - APort OpenClaw Plugin
 
+## 1.0.26
+
 ## 1.0.25
 
 ## 1.0.24

--- a/extensions/openclaw-aport/openclaw.plugin.json
+++ b/extensions/openclaw-aport/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclaw-aport",
   "name": "APort Guardrails",
   "description": "Deterministic pre-action authorization via APort policy enforcement. Registers before_tool_call to block disallowed tools.",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/openclaw-aport/package-lock.json
+++ b/extensions/openclaw-aport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -30,7 +30,7 @@
     },
     "extensions/openclaw-aport": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -15078,7 +15078,7 @@
     },
     "packages/claude-code": {
       "name": "@aporthq/aport-agent-guardrails-claude-code",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15093,7 +15093,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -15112,7 +15112,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15127,7 +15127,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15142,7 +15142,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15159,7 +15159,7 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22",
@@ -15178,7 +15178,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "workspaces": [
     "packages/*",

--- a/packages/claude-code/CHANGELOG.md
+++ b/packages/claude-code/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-claude-code
 
+## 1.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.26
+
 ## 1.0.25
 
 ### Patch Changes

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-claude-code",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "APort guardrails for Claude Code — PreToolUse hook",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.26"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-core
 
+## 1.0.26
+
+### Patch Changes
+
+- Release 1.0.26: add framework reset command, CI/install supply-chain hardening, and release dependency verification checks.
+
 ## 1.0.25
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crewai/CHANGELOG.md
+++ b/packages/crewai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-crewai
 
+## 1.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.26
+
 ## 1.0.25
 
 ### Patch Changes

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.26"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-cursor
 
+## 1.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.26
+
 ## 1.0.25
 
 ### Patch Changes

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.26"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
   "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
   "main": "index.js",

--- a/packages/langchain/CHANGELOG.md
+++ b/packages/langchain/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-langchain
 
+## 1.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.26
+
 ## 1.0.25
 
 ### Patch Changes

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.25",
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.26",
     "@langchain/core": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/n8n/CHANGELOG.md
+++ b/packages/n8n/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-n8n
 
+## 1.0.26
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.26
+
 ## 1.0.25
 
 ### Patch Changes

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.25"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.26"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/python/aport_guardrails/__init__.py
+++ b/python/aport_guardrails/__init__.py
@@ -3,7 +3,7 @@ aport_guardrails — Core evaluator, passport, and config for APort agent guardr
 Shared across Python framework adapters (LangChain, CrewAI, AutoGen).
 """
 
-__version__ = "1.0.25"
+__version__ = "1.0.26"
 
 from aport_guardrails.core.evaluator import Evaluator, Decision, ToolContext
 from aport_guardrails.core.passport import load_passport, validate_passport

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.25"
+version = "1.0.26"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.25"
+version = "1.0.26"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.25"
+version = "1.0.26"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -3,7 +3,13 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TMP_ROOT="${APORT_PRE_PUSH_TMP_ROOT:-/tmp/aport-prepush}"
+if [[ -n "${APORT_PRE_PUSH_TMP_ROOT:-}" ]]; then
+    TMP_ROOT="$APORT_PRE_PUSH_TMP_ROOT"
+    CLEANUP_TMP_ROOT=0
+else
+    TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aport-prepush.XXXXXX")"
+    CLEANUP_TMP_ROOT=1
+fi
 TEST_HOME="${APORT_PRE_PUSH_HOME:-$TMP_ROOT/home/default}"
 CREWAI_VENV="$TMP_ROOT/venvs/crewai"
 LANGCHAIN_VENV="$TMP_ROOT/venvs/langchain"
@@ -11,6 +17,13 @@ CREWAI_HOME="$TMP_ROOT/homes/crewai"
 LANGCHAIN_HOME="$TMP_ROOT/homes/langchain"
 OPENCLAW_HOME="$TMP_ROOT/openclaw"
 DEFAULT_AGENT_ID="ap_8955f5450cd542fe8f67bbbf07c3e103"
+
+cleanup() {
+    if [[ "${CLEANUP_TMP_ROOT:-0}" = "1" ]]; then
+        rm -rf "$TMP_ROOT"
+    fi
+}
+trap cleanup EXIT
 
 log_step() {
     printf '\n[%s] %s\n' "pre-push" "$1"
@@ -89,7 +102,7 @@ run_openclaw_e2e() {
     run_cmd "E2E OpenClaw CLI setup" bash -lc "
     cd '$REPO_ROOT'
     OPENCLAW_HOME='$OPENCLAW_HOME' AGENT_ID='${APORT_TEST_REMOTE_AGENT_ID:-$DEFAULT_AGENT_ID}' \
-      printf '\n\n\n\n' | ./bin/agent-guardrails --framework=openclaw \"\${AGENT_ID}\" >/tmp/aport-prepush-openclaw.log 2>&1 || true
+      printf '\n\n\n\n' | ./bin/agent-guardrails --framework=openclaw \"\${AGENT_ID}\" >'$TMP_ROOT/openclaw-cli.log' 2>&1 || true
     test -f '$OPENCLAW_HOME/config.yaml'
     grep -q 'agentId:' '$OPENCLAW_HOME/config.yaml'
   "

--- a/tests/unit/test-agent-guardrails-dispatcher.sh
+++ b/tests/unit/test-agent-guardrails-dispatcher.sh
@@ -196,6 +196,26 @@ grep -q "only supported for CrewAI" "$out10" || {
 }
 echo "  ✅ --integration-mode rejected for non-CrewAI frameworks"
 
+# 11. --non-interactive flag should set APORT_NONINTERACTIVE for custom frameworks
+out11="$TEST_DIR/dispatcher-11.txt"
+CLAUDE_FLAG_DIR="$TEST_DIR/claude_noninteractive_flag"
+mkdir -p "$CLAUDE_FLAG_DIR"
+set +e
+APORT_CLAUDE_CODE_CONFIG_DIR="$CLAUDE_FLAG_DIR" "$DISPATCHER" --framework=claude-code ap_04c65c1dd7224160b36b756960e2cc48 --non-interactive < /dev/null > "$out11" 2>&1
+e11=$?
+set -e
+[[ "$e11" -eq 0 ]] || {
+    echo "FAIL: --non-interactive flag should let hosted Claude setup finish without prompts" >&2
+    cat "$out11" >&2
+    exit 1
+}
+grep -q "Guardrail mode: api" "$out11" || {
+    echo "FAIL: expected Claude setup to complete in api mode" >&2
+    cat "$out11" >&2
+    exit 1
+}
+echo "  ✅ --non-interactive flag works for hosted Claude setup"
+
 echo ""
 echo "  All dispatcher tests passed."
 echo ""

--- a/tests/unit/test-framework-reset.sh
+++ b/tests/unit/test-framework-reset.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DISPATCHER="$REPO_ROOT/bin/agent-guardrails"
+TEST_DIR="${APORT_TEST_DIR:-$(mktemp -d 2> /dev/null || echo "$REPO_ROOT/tests/output")}"
+mkdir -p "$TEST_DIR"
+
+echo ""
+echo "  Unit/Integration — framework reset"
+echo "  Dispatcher: $DISPATCHER"
+echo ""
+
+CLAUDE_DIR="$TEST_DIR/.claude"
+mkdir -p "$CLAUDE_DIR/aport"
+
+cat > "$CLAUDE_DIR/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/tmp/aport-claude-code-hook.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/custom-claude-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+touch "$CLAUDE_DIR/aport/passport.json"
+
+echo "  Test: reset claude-code removes APort hook/config and preserves custom hooks..."
+APORT_CLAUDE_CODE_CONFIG_DIR="$CLAUDE_DIR" "$DISPATCHER" reset claude-code --yes > "$TEST_DIR/reset-1.txt" 2>&1
+
+if [[ -d "$CLAUDE_DIR/aport" ]]; then
+    echo "FAIL: expected $CLAUDE_DIR/aport to be removed" >&2
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "FAIL: jq is required for reset test" >&2
+    exit 1
+fi
+
+APORT_COUNT=$(jq -r '[.hooks.PreToolUse[]?.hooks[]? | select((.command // "") | test("aport-(cursor-hook|claude-code-hook)\\.sh$"))] | length' "$CLAUDE_DIR/settings.json")
+if [[ "$APORT_COUNT" -ne 0 ]]; then
+    echo "FAIL: expected APort Claude hook entries to be removed" >&2
+    cat "$CLAUDE_DIR/settings.json" >&2
+    exit 1
+fi
+
+CUSTOM_COUNT=$(jq -r '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/usr/local/bin/custom-claude-hook.sh")] | length' "$CLAUDE_DIR/settings.json")
+if [[ "$CUSTOM_COUNT" -ne 1 ]]; then
+    echo "FAIL: expected custom Claude hook to be preserved" >&2
+    cat "$CLAUDE_DIR/settings.json" >&2
+    exit 1
+fi
+
+echo "  ✅ reset claude-code cleans APort hook/config and preserves custom hooks"
+
+mkdir -p "$CLAUDE_DIR/aport"
+cat > "$CLAUDE_DIR/settings.json" << 'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/tmp/aport-claude-code-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+touch "$CLAUDE_DIR/aport/passport.json"
+
+echo "  Test: claude-code reset positional form works..."
+APORT_CLAUDE_CODE_CONFIG_DIR="$CLAUDE_DIR" "$DISPATCHER" claude-code reset --yes > "$TEST_DIR/reset-2.txt" 2>&1
+
+if [[ -d "$CLAUDE_DIR/aport" ]]; then
+    echo "FAIL: expected positional reset to remove $CLAUDE_DIR/aport" >&2
+    exit 1
+fi
+
+echo "  ✅ claude-code reset positional form works"
+
+echo ""
+echo "  Framework reset tests passed."
+echo ""


### PR DESCRIPTION
Add framework reset support with tests, harden workflow install/dependency verification paths against supply-chain risk, and sync the suite to 1.0.26.