### PR TITLE
Fix enterprise deploy legacy instance IDs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official APort plugins — security guardrails for AI coding agents",
-    "version": "1.0.28",
+    "version": "1.0.29",
     "license": "Apache-2.0",
     "homepage": "https://aport.io"
   },
@@ -17,7 +17,7 @@
       "source": {
         "source": "github",
         "repo": "aporthq/aport-agent-guardrails",
-        "ref": "v1.0.28"
+        "ref": "v1.0.29"
       },
       "keywords": [
         "security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aport-guardrails",
   "description": "APort Agent Guardrails — security policy enforcement for every tool call. Intercepts tool use, evaluates against your passport policy, and blocks unauthorized actions.",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "author": {
     "name": "APort Technologies Inc.",
     "email": "hello@aport.io",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.29] - 2026-05-28
+
+### Fixed
+- Enterprise device deployment now supports template instances returned with legacy `agt_inst_*` passport IDs, preserving hosted/API mode instead of failing validation or falling back to local setup.
+- Enterprise script API failures now surface HTTP status and API error messages without raw Node stack traces.
+
+### Added
+- Public IT deployment guide for deploy, enforce, and uninstall scripts.
+
+## [1.0.28] - 2026-05-28
+
+### Fixed
+- Hosted setup and framework hook paths were hardened so tests and non-interactive setup stay isolated from real local Claude Code and Cursor configuration.
+- Enterprise script delivery was tightened for curl-based installs.
+
 ## [1.0.27] - 2026-05-21
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ npx --yes @aporthq/aport-agent-guardrails claude-code --non-interactive
 
 - **I need OpenClaw now:** [docs/QUICKSTART_OPENCLAW_PLUGIN.md](docs/QUICKSTART_OPENCLAW_PLUGIN.md)
 - **I already have agent_id:** [docs/HOSTED_PASSPORT_SETUP.md](docs/HOSTED_PASSPORT_SETUP.md)
+- **I’m deploying for an IT team:** [docs/ENTERPRISE_DEVICE_DEPLOYMENT.md](docs/ENTERPRISE_DEVICE_DEPLOYMENT.md)
 - **I need framework setup docs:** [docs/frameworks](docs/frameworks)
 - **I want Claude marketplace install:** [docs/frameworks/claude-code.md](docs/frameworks/claude-code.md#marketplace-install-claude-plugins)
 
@@ -118,7 +119,7 @@ The security concern is that agent tools and skills can execute sensitive action
 
 **Two ways to use APort:** (1) **Guardrails (CLI/setup)** — run the installer to create your passport and config; (2) **Core (library)** — use the `OAPGuardrailProvider` ([docs/PROVIDER.md](docs/PROVIDER.md)) in your app so each tool call is verified. One provider per language (Python + TypeScript), works with any framework. Framework docs: [OpenClaw](docs/frameworks/openclaw.md), [Cursor](docs/frameworks/cursor.md), [Claude Code](docs/frameworks/claude-code.md), [LangChain](docs/frameworks/langchain.md), [CrewAI](docs/frameworks/crewai.md), [DeerFlow](docs/frameworks/deerflow.md), [n8n](docs/frameworks/n8n.md).
 
-**CLI-supported frameworks:** `openclaw`, `langchain`, `crewai`, `cursor`, `claude-code`, `deerflow`, `n8n`. OpenClaw/Cursor/Claude Code include runtime-specific integration scripts; DeerFlow/LangChain/CrewAI use framework docs plus generic setup output from the CLI. See [Deployment readiness](docs/DEPLOYMENT_READINESS.md).
+**CLI-supported frameworks:** `openclaw`, `langchain`, `crewai`, `cursor`, `claude-code`, `deerflow`, `n8n`. OpenClaw/Cursor/Claude Code include runtime-specific integration scripts; DeerFlow/LangChain/CrewAI use framework docs plus generic setup output from the CLI. For IT-managed device rollout, see [Enterprise device deployment](docs/ENTERPRISE_DEVICE_DEPLOYMENT.md).
 
 | Framework | Doc | Integration | Install |
 |-----------|-----|--------------|--------|

--- a/bin/frameworks/generic.sh
+++ b/bin/frameworks/generic.sh
@@ -48,7 +48,11 @@ while [[ ${#remaining_args[@]} -gt 0 ]]; do
             crewai_integration_mode="${remaining_args[0]}"
             remaining_args=("${remaining_args[@]:1}")
             ;;
-        ap_[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9])
+        ap_* | apt_* | agt_inst_* | agt_tmpl_*)
+            if ! is_aport_hosted_agent_id "$arg"; then
+                log_error "Invalid hosted passport ID format: $arg"
+                exit 1
+            fi
             hosted_agent_id="$arg"
             ;;
         *)

--- a/bin/lib/guardrail-mode.sh
+++ b/bin/lib/guardrail-mode.sh
@@ -5,6 +5,10 @@
 
 DEFAULT_APORT_API_URL="${DEFAULT_APORT_API_URL:-https://api.aport.io}"
 
+is_aport_hosted_agent_id() {
+    [[ "${1:-}" =~ ^(ap|apt|agt_inst|agt_tmpl)_[A-Za-z0-9_-]+$ ]]
+}
+
 parse_guardrail_mode_args() {
     APORT_GUARDRAIL_MODE_CLI="${APORT_GUARDRAIL_MODE_CLI:-}"
     APORT_GUARDRAIL_API_URL_CLI="${APORT_GUARDRAIL_API_URL_CLI:-}"
@@ -66,7 +70,11 @@ parse_guardrail_mode_args() {
                 APORT_ISSUE_URL_CLI="$2"
                 shift
                 ;;
-            ap_[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9])
+            ap_* | apt_* | agt_inst_* | agt_tmpl_*)
+                if ! is_aport_hosted_agent_id "$1"; then
+                    echo "[aport] ERROR: Invalid hosted passport ID format: $1" >&2
+                    return 1
+                fi
                 APORT_HOSTED_AGENT_ID_CLI="$1"
                 ;;
             *)

--- a/bin/openclaw
+++ b/bin/openclaw
@@ -126,12 +126,12 @@ if [ -n "${1:-}" ]; then
 		echo "See: https://github.com/aporthq/aport-agent-guardrails/tree/main/docs"
 		exit 0
 	fi
-	# Validate agent_id format (ap_ followed by 32 hex chars)
-	if [[ "$1" =~ ^ap_[a-f0-9]{32}$ ]]; then
+	# Validate agent_id format.
+	if [[ "$1" =~ ^(ap|apt|agt_inst|agt_tmpl)_[A-Za-z0-9_-]+$ ]]; then
 		HOSTED_AGENT_ID="$1"
 	else
 		echo "❌ Invalid agent_id format: $1"
-		echo "   Expected: ap_[32 hex characters]"
+		echo "   Expected: ap_..., apt_..., agt_inst_..., or agt_tmpl_..."
 		echo "   Example: ap_fa2f6d53bb5b4c98b9af0124285b6e0f"
 		echo ""
 		echo "Run '$0 --help' for usage information."

--- a/docs/ENTERPRISE_DEVICE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEVICE_DEPLOYMENT.md
@@ -1,0 +1,153 @@
+# Enterprise Device Deployment
+
+Use this guide when an IT team wants to deploy APort guardrails to one or many developer machines through a device-management tool, remote shell, or manual test run.
+
+The deployment scripts are generic. They work for MDM tools, endpoint-management tools, remote shell runners, or a saved script executed by an administrator.
+
+## What Gets Installed
+
+The deploy script:
+
+1. Identifies the target device and user.
+2. Reuses an existing passport instance for that device when one already exists.
+3. Creates a new instance from the template passport only when needed.
+4. Mints a narrow runtime setup key for that instance.
+5. Runs `npx @aporthq/aport-agent-guardrails <framework> <agent_id> --mode=api`.
+6. Writes the framework hook/config for the target user.
+
+The org enrollment key is not stored for runtime. Hooks use the minted runtime key.
+
+## Requirements
+
+Each target device needs:
+
+- Node.js 18+
+- npm/npx
+- curl
+- The target agent framework installed or available to the developer, for example Claude Code or Cursor
+
+APort setup requires:
+
+- A template passport in the APort org.
+- An org API key with `issue` scope. Use the narrowest key available; do not use a broad admin key.
+- The framework name, for example `claude-code` or `cursor`.
+
+## Recommended First Test
+
+Run the deploy script on one developer test machine first.
+
+```bash
+export APORT_API_KEY="apk_..."
+export APORT_TEMPLATE_ID="ap_..."
+export APORT_FRAMEWORK="claude-code"
+
+curl -fsSL "https://api.aport.io/enterprise/scripts/deploy?version=1.0.29" | bash
+```
+
+If the script runs as `root`, set the developer account explicitly:
+
+```bash
+export APORT_TARGET_USER="developer"
+export APORT_TARGET_HOME="/Users/developer"
+```
+
+For Linux, `APORT_TARGET_HOME` is usually `/home/<user>`.
+
+## Script Commands
+
+| Command | URL | Purpose |
+| --- | --- | --- |
+| Deploy | `https://api.aport.io/enterprise/scripts/deploy?version=1.0.29` | Initial install or repair |
+| Enforce | `https://api.aport.io/enterprise/scripts/enforce?version=1.0.29` | Validate state and reinstall if the hook/config is missing |
+| Uninstall | `https://api.aport.io/enterprise/scripts/uninstall?version=1.0.29` | Remove APort-owned wiring and local state |
+
+Use `deploy` for the first test. Use `enforce` as the recurring compliance script. Use `uninstall` only for approved removal.
+
+## Configuration Variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `APORT_API_KEY` | Deploy/enforce | Org enrollment key with `issue` scope |
+| `APORT_TEMPLATE_ID` | Deploy/enforce | Template passport ID to instantiate per device/user |
+| `APORT_FRAMEWORK` | All | `claude-code`, `cursor`, `openclaw`, `langchain`, `crewai`, `deerflow`, or `n8n` |
+| `APORT_API_URL` | No | Defaults to `https://api.aport.io` |
+| `APORT_TARGET_USER` | No | Developer account that runs the agent framework |
+| `APORT_TARGET_HOME` | No | Home/profile directory for the target user |
+| `APORT_DEVICE_ID` | No | Stable device identifier; auto-detected when unset |
+| `APORT_STATE_DIR` | No | Override local system state directory |
+| `DISABLE_DEVICE_INFO` | No | Set to `1` to skip device metadata collection |
+
+## How Device Identity Works
+
+The script derives a stable `tenant_ref` from:
+
+- device ID
+- target username
+- framework
+- template passport ID
+
+This prevents duplicate passport instances when the deploy or enforce script runs again on the same device for the same user/framework/template.
+
+Device ID is auto-detected from:
+
+- macOS: hardware serial number
+- Linux: machine ID
+- Windows: BIOS serial number
+- fallback: hostname
+
+Set `APORT_DEVICE_ID` if the device-management system has a stronger stable identifier.
+
+## Verify The Install
+
+After deploy:
+
+1. Open APort and switch to the org context.
+2. Open the template passport.
+3. Confirm an instance exists for the test device.
+4. Ask the developer to run a normal Claude Code or Cursor task.
+5. Confirm allow/deny decisions appear in APort audit.
+
+For a pilot, use a test repository and prompts that exercise both normal developer actions and blocked actions, for example safe repo inspection, test execution, destructive cleanup, privileged commands, and sensitive file reads.
+
+## Enforcement Script
+
+Run this as the recurring compliance check:
+
+```bash
+export APORT_API_KEY="apk_..."
+export APORT_TEMPLATE_ID="ap_..."
+export APORT_FRAMEWORK="claude-code"
+
+curl -fsSL "https://api.aport.io/enterprise/scripts/enforce?version=1.0.29" | bash
+```
+
+`enforce` reuses existing local state when present. If the framework hook/config is missing, it reinstalls without creating a duplicate passport instance.
+
+## Uninstall
+
+Use only for approved removal:
+
+```bash
+export APORT_FRAMEWORK="claude-code"
+
+curl -fsSL "https://api.aport.io/enterprise/scripts/uninstall?version=1.0.29" | bash
+```
+
+Uninstall removes APort-owned framework wiring and local APort state for the selected framework. It does not delete the passport or audit records from APort.
+
+## Auditable Download
+
+For stricter change-control, fetch the manifest and verify the script hash before execution:
+
+```bash
+curl -fsSL "https://api.aport.io/enterprise/scripts?version=1.0.29"
+curl -fsSL "https://api.aport.io/enterprise/scripts/deploy?version=1.0.29" -o /tmp/aport-deploy.sh
+shasum -a 256 /tmp/aport-deploy.sh
+bash /tmp/aport-deploy.sh
+```
+
+Compare the `shasum` output to the manifest’s `sha256` value.
+
+## More Detail
+
+The source scripts and implementation notes are in [`enterprise-scripts/README.md`](../enterprise-scripts/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 | [QUICKSTART_OPENCLAW_PLUGIN.md](QUICKSTART_OPENCLAW_PLUGIN.md) | **OpenClaw plugin** — one-command setup, deterministic enforcement (RECOMMENDED) |
 | [**HOSTED_PASSPORT_SETUP.md**](HOSTED_PASSPORT_SETUP.md) | **Use passport from aport.io** — create hosted during setup or pass `npx @aporthq/aport-agent-guardrails openclaw <agent_id>` |
 | [QUICKSTART.md](QUICKSTART.md) | Interactive setup and step-by-step hosted/local passport options |
+| [ENTERPRISE_DEVICE_DEPLOYMENT.md](ENTERPRISE_DEVICE_DEPLOYMENT.md) | IT-managed deploy, enforce, and uninstall scripts |
 | [OPENCLAW_LOCAL_INTEGRATION.md](OPENCLAW_LOCAL_INTEGRATION.md) | Full OpenClaw setup: API, passport, policies, Python example |
 | [OPENCLAW_TOOLS_AND_POLICIES.md](OPENCLAW_TOOLS_AND_POLICIES.md) | exec, allowed_commands, unmapped tools, passport limits |
 | [TOOL_POLICY_MAPPING.md](TOOL_POLICY_MAPPING.md) | How tool names map to policy packs |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release process and version policy
 
-**Current release:** 1.0.28 (see [CHANGELOG.md](../CHANGELOG.md)).
+**Current release:** 1.0.29 (see [CHANGELOG.md](../CHANGELOG.md)).
 
 We keep **one version number** across all published packages (Node core, Python core, and every framework adapter). That avoids “core is 1.2 but CLI is 0.9” and keeps the story simple for users and support.
 

--- a/enterprise-scripts/README.md
+++ b/enterprise-scripts/README.md
@@ -55,7 +55,7 @@ The setup-key API **always** creates `scopes: ["read"]` and does not accept cust
 | Variable | Required | Purpose |
 | --- | --- | --- |
 | `APORT_API_KEY` | Deploy/enforce | Org enrollment key with **`issue`** scope (`apk_…`); not the runtime setup key |
-| `APORT_TEMPLATE_ID` | Deploy/enforce | Template passport ID (`ap_…` / `apt_…`); script creates per-device **instances** (`ap_instance_…`) |
+| `APORT_TEMPLATE_ID` | Deploy/enforce | Template passport ID (`ap_…` / `apt_…`); script creates per-device **instances** (`agt_inst_…` / `ap_…`) |
 | `APORT_FRAMEWORK` | All | e.g. `claude-code`, `cursor` |
 | `APORT_TARGET_USER` | No | Account that runs the agent (auto-detected if unset) |
 | `APORT_TARGET_HOME` | No | Profile/home path (auto-detected if unset) |
@@ -96,8 +96,8 @@ The API serves **bundled** scripts (config header + inlined `aport-device-core.m
 Do **not** pipe the thin repo scripts (`enterprise-scripts/aport-device-*.sh`) through bash; those require `aport-device-lib.sh` on disk.
 
 ```bash
-curl -fsSL "https://api.aport.io/enterprise/scripts?version=1.0.27"
-curl -fsSL "https://api.aport.io/enterprise/scripts/deploy?version=1.0.27" -o /tmp/aport-deploy.sh
+curl -fsSL "https://api.aport.io/enterprise/scripts?version=1.0.29"
+curl -fsSL "https://api.aport.io/enterprise/scripts/deploy?version=1.0.29" -o /tmp/aport-deploy.sh
 shasum -a 256 -c <<< "<sha256>  /tmp/aport-deploy.sh"
 bash /tmp/aport-deploy.sh
 ```

--- a/enterprise-scripts/aport-device-core.mjs
+++ b/enterprise-scripts/aport-device-core.mjs
@@ -56,9 +56,13 @@ function assertSafeUsername(user) {
   }
 }
 
+function isSafeAportPassportId(id) {
+  return /^(ap|apt|agt_inst|agt_tmpl)_[a-zA-Z0-9_-]+$/.test(id);
+}
+
 function assertSafePassportId(id, label) {
-  if (!/^(ap|apt)_[a-zA-Z0-9_-]+$/.test(id)) {
-    die(`${label} must be a valid APort passport id (ap_... or apt_...)`);
+  if (!isSafeAportPassportId(id)) {
+    die(`${label} must be a valid APort passport id (ap_..., apt_..., agt_inst_..., or agt_tmpl_...)`);
   }
 }
 
@@ -150,13 +154,52 @@ function run(cmd, args, options = {}) {
   return result;
 }
 
+function formatHttpError(status, body) {
+  const trimmed = String(body || '').trim();
+  let message = trimmed;
+  try {
+    const parsed = JSON.parse(trimmed);
+    message =
+      parsed?.error?.message ||
+      parsed?.error ||
+      parsed?.message ||
+      parsed?.detail ||
+      JSON.stringify(parsed);
+  } catch {
+    /* Use raw body below. */
+  }
+  const suffix = message ? `: ${message}` : '';
+  return `HTTP ${status}${suffix}`;
+}
+
 function curl(args) {
-  const result = run('curl', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const marker = '\n__APORT_HTTP_STATUS__:';
+  const normalizedArgs = [];
+  for (const arg of args) {
+    if (arg === '-fsS') {
+      normalizedArgs.push('-sS');
+      continue;
+    }
+    if (arg === '-f' || arg === '--fail') continue;
+    normalizedArgs.push(arg);
+  }
+
+  const result = run('curl', ['-w', `${marker}%{http_code}`, ...normalizedArgs], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
   if (result.status !== 0) {
     const err = (result.stderr || result.stdout || '').trim();
     throw new Error(err || `curl exited ${result.status}`);
   }
-  return result.stdout;
+  const stdout = result.stdout || '';
+  const idx = stdout.lastIndexOf(marker);
+  if (idx === -1) return stdout;
+  const body = stdout.slice(0, idx);
+  const status = Number(stdout.slice(idx + marker.length).trim());
+  if (Number.isFinite(status) && status >= 400) {
+    throw new Error(formatHttpError(status, body));
+  }
+  return body;
 }
 
 function targetUser(cfg) {
@@ -385,9 +428,9 @@ function findExistingInstance(cfg, tenantRef) {
   let response;
   try {
     response = curl(['-fsS', url]);
-  } catch {
+  } catch (error) {
     die(
-      'Could not verify whether this device already has a passport instance. Aborting to avoid duplicate issuance.'
+      `Could not verify whether this device already has a passport instance. Aborting to avoid duplicate issuance. ${error.message}`
     );
   }
   const data = JSON.parse(response);
@@ -414,18 +457,25 @@ function createInstance(cfg, tenantRef, user, deviceInfoJson) {
   };
   if (deviceInfoJson) body.device_info = JSON.parse(deviceInfoJson);
 
-  const response = curl([
-    '-fsS',
-    '-X',
-    'POST',
-    `${cfg.apiUrl}/api/passports/${cfg.templateId}/instances`,
-    '-H',
-    'Content-Type: application/json',
-    '-H',
-    `Authorization: Bearer ${cfg.apiKey}`,
-    '-d',
-    JSON.stringify(body),
-  ]);
+  let response;
+  try {
+    response = curl([
+      '-fsS',
+      '-X',
+      'POST',
+      `${cfg.apiUrl}/api/passports/${cfg.templateId}/instances`,
+      '-H',
+      'Content-Type: application/json',
+      '-H',
+      `Authorization: Bearer ${cfg.apiKey}`,
+      '-d',
+      JSON.stringify(body),
+    ]);
+  } catch (error) {
+    die(
+      `Could not create passport instance from template ${cfg.templateId}. Check that APORT_API_KEY has issue scope and belongs to the org that owns or can issue this template. ${error.message}`
+    );
+  }
   const data = JSON.parse(response);
   const agentId = jsonGet(data, 'instance_id') || jsonGet(data, 'data.instance_id');
   if (!agentId) die('Instance create response did not include instance_id');
@@ -433,18 +483,25 @@ function createInstance(cfg, tenantRef, user, deviceInfoJson) {
 }
 
 function createRuntimeSetupKey(cfg, agentId) {
-  const response = curl([
-    '-fsS',
-    '-X',
-    'POST',
-    `${cfg.apiUrl}/api/passports/${agentId}/setup-key`,
-    '-H',
-    'Content-Type: application/json',
-    '-H',
-    `Authorization: Bearer ${cfg.apiKey}`,
-    '-d',
-    JSON.stringify({ name: `${cfg.framework} device runtime key for ${agentId}` }),
-  ]);
+  let response;
+  try {
+    response = curl([
+      '-fsS',
+      '-X',
+      'POST',
+      `${cfg.apiUrl}/api/passports/${agentId}/setup-key`,
+      '-H',
+      'Content-Type: application/json',
+      '-H',
+      `Authorization: Bearer ${cfg.apiKey}`,
+      '-d',
+      JSON.stringify({ name: `${cfg.framework} device runtime key for ${agentId}` }),
+    ]);
+  } catch (error) {
+    die(
+      `Could not create runtime setup key for ${agentId}. Check that APORT_API_KEY can access this passport and has the required issue permission. ${error.message}`
+    );
+  }
   const data = JSON.parse(response);
   const key = jsonGet(data, 'key') || jsonGet(data, 'data.key');
   if (!key) die('Setup key response did not include a plaintext key');

--- a/extensions/openclaw-aport/CHANGELOG.md
+++ b/extensions/openclaw-aport/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog - APort OpenClaw Plugin
 
+## 1.0.29
+
 ## 1.0.28
 
 ## 1.0.27

--- a/extensions/openclaw-aport/openclaw.plugin.json
+++ b/extensions/openclaw-aport/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclaw-aport",
   "name": "APort Guardrails",
   "description": "Deterministic pre-action authorization via APort policy enforcement. Registers before_tool_call to block disallowed tools.",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/openclaw-aport/package-lock.json
+++ b/extensions/openclaw-aport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -30,7 +30,7 @@
     },
     "extensions/openclaw-aport": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -15078,7 +15078,7 @@
     },
     "packages/claude-code": {
       "name": "@aporthq/aport-agent-guardrails-claude-code",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15093,7 +15093,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -15112,7 +15112,7 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15127,7 +15127,7 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"
@@ -15142,7 +15142,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15159,7 +15159,7 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22",
@@ -15178,7 +15178,7 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@aporthq/aport-agent-guardrails-core": ">=1.0.22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Policy enforcement guardrails for OpenClaw-compatible agent frameworks",
   "workspaces": [
     "packages/*",

--- a/packages/claude-code/CHANGELOG.md
+++ b/packages/claude-code/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-claude-code
 
+## 1.0.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.29
+
 ## 1.0.28
 
 ### Patch Changes

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-claude-code",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "APort guardrails for Claude Code — PreToolUse hook",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.28"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.29"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aporthq/aport-agent-guardrails-core
 
+## 1.0.29
+
+### Patch Changes
+
+- Fix enterprise device deployment for template instances that use legacy `agt_inst_` passport IDs.
+
 ## 1.0.28
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/crewai/CHANGELOG.md
+++ b/packages/crewai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-crewai
 
+## 1.0.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.29
+
 ## 1.0.28
 
 ### Patch Changes

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.28"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.29"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-cursor
 
+## 1.0.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.29
+
 ## 1.0.28
 
 ### Patch Changes

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.28"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.29"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
   "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
   "main": "index.js",

--- a/packages/langchain/CHANGELOG.md
+++ b/packages/langchain/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-langchain
 
+## 1.0.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.29
+
 ## 1.0.28
 
 ### Patch Changes

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.28",
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.29",
     "@langchain/core": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/n8n/CHANGELOG.md
+++ b/packages/n8n/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-n8n
 
+## 1.0.29
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.29
+
 ## 1.0.28
 
 ### Patch Changes

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.28"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.29"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/python/aport_guardrails/__init__.py
+++ b/python/aport_guardrails/__init__.py
@@ -3,7 +3,7 @@ aport_guardrails — Core evaluator, passport, and config for APort agent guardr
 Shared across Python framework adapters (LangChain, CrewAI, AutoGen).
 """
 
-__version__ = "1.0.28"
+__version__ = "1.0.29"
 
 from aport_guardrails.core.evaluator import Evaluator, Decision, ToolContext
 from aport_guardrails.core.passport import load_passport, validate_passport

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.28"
+version = "1.0.29"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.28"
+version = "1.0.29"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.28"
+version = "1.0.29"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/unit/test-agent-guardrails-dispatcher.sh
+++ b/tests/unit/test-agent-guardrails-dispatcher.sh
@@ -204,7 +204,7 @@ out11="$TEST_DIR/dispatcher-11.txt"
 CLAUDE_FLAG_DIR="$TEST_DIR/claude_noninteractive_flag"
 mkdir -p "$CLAUDE_FLAG_DIR"
 set +e
-APORT_CLAUDE_CODE_CONFIG_DIR="$CLAUDE_FLAG_DIR" "$DISPATCHER" --framework=claude-code ap_04c65c1dd7224160b36b756960e2cc48 --non-interactive < /dev/null > "$out11" 2>&1
+APORT_CLAUDE_CODE_CONFIG_DIR="$CLAUDE_FLAG_DIR" "$DISPATCHER" --framework=claude-code agt_inst_mppi38zb_ogxgbi --non-interactive < /dev/null > "$out11" 2>&1
 e11=$?
 set -e
 [[ "$e11" -eq 0 ]] || {
@@ -215,6 +215,11 @@ set -e
 grep -q "Guardrail mode: api" "$out11" || {
     echo "FAIL: expected Claude setup to complete in api mode" >&2
     cat "$out11" >&2
+    exit 1
+}
+grep -q 'APORT_AGENT_ID=agt_inst_mppi38zb_ogxgbi' "$CLAUDE_FLAG_DIR/aport/guardrail-mode.env" || {
+    echo "FAIL: expected legacy instance ID to be persisted as hosted agent ID" >&2
+    cat "$CLAUDE_FLAG_DIR/aport/guardrail-mode.env" >&2
     exit 1
 }
 echo "  ✅ --non-interactive flag works for hosted Claude setup"

--- a/tests/unit/test-enterprise-device-scripts.sh
+++ b/tests/unit/test-enterprise-device-scripts.sh
@@ -69,7 +69,11 @@ case "$*" in
         printf '{"exists":false}'
         ;;
     *"/api/passports/"*"/instances"*)
-        printf '{"instance_id":"ap_instance_1234567890abcdef1234567890abcdef"}'
+        if [ "${APORT_TEST_CREATE_INSTANCE_FORBIDDEN:-}" = "1" ]; then
+            printf '{"error":"Insufficient permissions to access this passport"}\n__APORT_HTTP_STATUS__:403'
+            exit 0
+        fi
+        printf '{"instance_id":"agt_inst_mppi38zb_ogxgbi"}'
         ;;
     *"/api/passports/"*"/setup-key"*)
         printf '{"key":"apk_runtime_test"}'
@@ -110,7 +114,7 @@ PATH="$FAKE_BIN:$PATH" \
 STATE_FILE="$STATE_DIR/state.env"
 MODE_FILE="$HOME_DIR/.claude/aport/guardrail-mode.env"
 
-grep -qE 'APORT_AGENT_ID=("|\047)?ap_instance_1234567890abcdef1234567890abcdef' "$STATE_FILE" || {
+grep -qE 'APORT_AGENT_ID=("|\047)?agt_inst_mppi38zb_ogxgbi' "$STATE_FILE" || {
     echo "FAIL: state should persist the created agent id" >&2
     cat "$STATE_FILE" >&2
     exit 1
@@ -133,7 +137,7 @@ grep -q 'APORT_API_KEY=apk_runtime_test' "$APORT_TEST_NPX_LOG" || {
     echo "FAIL: npx installer should receive runtime setup key" >&2
     exit 1
 }
-grep -q '/api/passports/ap_instance_1234567890abcdef1234567890abcdef/setup-key' "$APORT_TEST_CURL_LOG" || {
+grep -q '/api/passports/agt_inst_mppi38zb_ogxgbi/setup-key' "$APORT_TEST_CURL_LOG" || {
     echo "FAIL: install should mint runtime setup key for created instance" >&2
     exit 1
 }
@@ -234,6 +238,44 @@ fi
 if grep -q '/instances' "$APORT_TEST_CURL_LOG"; then
     echo "FAIL: install should not create an instance after lookup failure" >&2
     cat "$APORT_TEST_CURL_LOG" >&2
+    exit 1
+fi
+
+CREATE_FAIL_STATE_DIR="$TMP_DIR/create-fail-state"
+: > "$APORT_TEST_CURL_LOG"
+set +e
+PATH="$FAKE_BIN:$PATH" \
+    APORT_SKIP_USER_SWITCH=1 \
+    APORT_TARGET_USER="testuser" \
+    APORT_TARGET_HOME="$HOME_DIR" \
+    APORT_STATE_DIR="$CREATE_FAIL_STATE_DIR" \
+    APORT_DEVICE_ID="device-123" \
+    APORT_API_KEY="apk_enrollment_test" \
+    APORT_TEMPLATE_ID="ap_template_test" \
+    APORT_FRAMEWORK="claude-code" \
+    APORT_TEST_CREATE_INSTANCE_FORBIDDEN=1 \
+    bash "$SCRIPT" > "$LOG_DIR/create-fail.out" 2>&1
+CREATE_FAIL_EXIT=$?
+set -e
+
+if [ "$CREATE_FAIL_EXIT" -eq 0 ]; then
+    echo "FAIL: install should fail when instance create is forbidden" >&2
+    cat "$LOG_DIR/create-fail.out" >&2
+    exit 1
+fi
+grep -q 'Could not create passport instance' "$LOG_DIR/create-fail.out" || {
+    echo "FAIL: create forbidden error should explain the failed operation" >&2
+    cat "$LOG_DIR/create-fail.out" >&2
+    exit 1
+}
+grep -q 'HTTP 403: Insufficient permissions to access this passport' "$LOG_DIR/create-fail.out" || {
+    echo "FAIL: create forbidden error should include HTTP status and API message" >&2
+    cat "$LOG_DIR/create-fail.out" >&2
+    exit 1
+}
+if grep -q 'ModuleJob.run\|at curl (file:' "$LOG_DIR/create-fail.out"; then
+    echo "FAIL: create forbidden error should not show a raw Node stack" >&2
+    cat "$LOG_DIR/create-fail.out" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Summary
- accept legacy agt_inst/agt_tmpl hosted passport IDs in enterprise deploy and framework hosted setup
- improve enterprise script API error messages so 403s show the API reason without a raw Node stack
- add public enterprise device deployment docs and bump package versions to 1.0.29

Tests
- npm run build
- git diff --check
- node --check enterprise-scripts/aport-device-core.mjs
- shfmt -d bin/lib/guardrail-mode.sh bin/frameworks/generic.sh bin/openclaw tests/unit/test-agent-guardrails-dispatcher.sh tests/unit/test-enterprise-device-scripts.sh
- APORT_TEST_RUN_ROOT=/tmp/aport-guardrails-1.0.29-final APORT_SKIP_REMOTE_PASSPORT_TEST=1 make test (All 45 passed)