### PR TITLE
Release guardrails 1.0.32

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Official APort plugins — security guardrails for AI coding agents",
-    "version": "1.0.31",
+    "version": "1.0.32",
     "license": "Apache-2.0",
     "homepage": "https://aport.io"
   },
@@ -17,7 +17,7 @@
       "source": {
         "source": "github",
         "repo": "aporthq/aport-agent-guardrails",
-        "ref": "v1.0.31"
+        "ref": "v1.0.32"
       },
       "keywords": [
         "security",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aport-guardrails",
   "description": "APort Agent Guardrails — security policy enforcement for every tool call. Intercepts tool use, evaluates against your passport policy, and blocks unauthorized actions.",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "author": {
     "name": "APort Technologies Inc.",
     "email": "hello@aport.io",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.32] - 2026-09-05
+
+### Changed
+- Hosted guardrail clients now report runtime enforcement metadata (`enforce` vs `warn`) to APort so the dashboard can distinguish the signed policy decision from the framework's runtime disposition.
+- Report-only guardrail warnings now use shared sanitized display helpers across Claude Code, Cursor, LangChain, and CrewAI.
+
+### Fixed
+- Warn-mode hook responses consistently surface the original APort deny reason without blocking execution when report-only rollout is explicitly enabled.
+
 ## [1.0.31] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This runs setup and writes config for your framework. Choose hosted setup for pa
 
 **Guardrail mode (local vs API)** — On the **Node** installer (`npx @aporthq/aport-agent-guardrails …` / `bin/agent-guardrails`), every framework accepts the same flags: `--mode=api` (with optional `--api-url`, default `https://api.aport.io`) or `--mode=local`, and an optional hosted `ap_<hex>` argument (API mode, no local passport). That flow writes `…/aport/guardrail-mode.env` where the hooks/generic installers need it. The **Python** `aport setup` CLI does not parse those flags yet; use the Node command above for API/local mode during setup, or set mode in your framework `config.yaml` per the framework doc.
 
-**Enforcement mode (block vs warn)** — Default is `enforce`: APort fails closed and policy denials block the tool call. Use `--enforcement=warn` only when intentionally rolling out in report-only/audit mode. Warn mode still evaluates policy and records the original deny decision, but lets the framework action continue so teams can tune passports without interrupting development.
+**Enforcement mode (block vs warn)** — Default is `enforce`: APort fails closed and policy denials block the tool call. Use `--enforcement=warn` only when intentionally rolling out in report-only/audit mode. Warn mode still evaluates policy and records the original deny decision, but lets the framework action continue so teams can tune passports without interrupting development. Host visibility differs: Claude Code shows a `systemMessage` warning; Cursor returns best-effort warning fields but may not display allow warnings in the UI, so use the audit log/status output as the source of truth. See APort's [OAP Decisions vs Harness Enforcement](https://github.com/aporthq/agent-passport/blob/main/docs/DECISION-VS-ENFORCEMENT.md) guidance for how to reconcile signed `allow: false` decisions with local warn/report-only rollout.
 
 Change enforcement later without creating a new passport or reinstalling hooks:
 
@@ -533,13 +533,13 @@ Use the framework-specific doc for where config and passport live and for any ex
 
 | Doc | Description |
 |-----|-------------|
-| [QuickStart: OpenClaw Plugin](docs/QUICKSTART_OPENCLAW_PLUGIN.md) | One-command OpenClaw setup |
-| [Hosted passport setup](docs/HOSTED_PASSPORT_SETUP.md) | Use passport from aport.io — `npx ... openclaw <agent_id>` or choose hosted in wizard |
-| [Verification methods (local vs API)](docs/VERIFICATION_METHODS.md) | Deep dive: bash vs API evaluator |
 | [Quick Start Guide](docs/QUICKSTART.md) | Passport wizard, copy-paste option |
-| [OpenClaw Local Integration](docs/OPENCLAW_LOCAL_INTEGRATION.md) | API, Python example |
-| [Tool / Policy Mapping](docs/TOOL_POLICY_MAPPING.md) | Tool names → policy packs |
 | [GitHub Protection](docs/GITHUB_PROTECTION.md) | Protect PR/push workflows with hosted OAP verification and explicit release checks |
+| [Hosted passport setup](docs/HOSTED_PASSPORT_SETUP.md) | Use passport from aport.io with any supported framework: `npx ... <framework> <agent_id>` or choose hosted in wizard |
+| [Verification methods (local vs API)](docs/VERIFICATION_METHODS.md) | Deep dive: bash vs API evaluator |
+| [Tool / Policy Mapping](docs/TOOL_POLICY_MAPPING.md) | Tool names → policy packs |
+| [QuickStart: OpenClaw Plugin](docs/QUICKSTART_OPENCLAW_PLUGIN.md) | One-command OpenClaw setup |
+| [OpenClaw Local Integration](docs/OPENCLAW_LOCAL_INTEGRATION.md) | API, Python example |
 | [Repo Layout](docs/REPO_LAYOUT.md) | For contributors: package layout (`bin/`, `src/`, `extensions/`) |
 | [Upgrade Guide](docs/UPGRADE.md) | Migrating between versions (e.g. 0.1.0 → 1.0.0) |
 | **Frameworks** | Per-framework setup and how guardrails run |

--- a/bin/aport-claude-code-hook.sh
+++ b/bin/aport-claude-code-hook.sh
@@ -57,22 +57,16 @@ fi
 
 emit_claude_input_too_large() {
     local decision="deny"
-    local notice
+    local notice user_warning
     if aport_hook_is_warn_mode; then
         decision="allow"
         notice="$(aport_format_guardrail_notice warn hook.input oap.input_too_large "Hook payload exceeded ${APORT_HOOK_STDIN_MAX_BYTES} bytes.")"
+        user_warning="$(aport_hook_format_user_warning hook.input oap.input_too_large "Hook payload exceeded ${APORT_HOOK_STDIN_MAX_BYTES} bytes.")"
     else
         notice="$(aport_format_guardrail_notice deny hook.input oap.input_too_large "Hook payload exceeded ${APORT_HOOK_STDIN_MAX_BYTES} bytes.")"
     fi
 
-    if command -v jq > /dev/null 2>&1; then
-        jq -n --arg reason "$notice" --arg event "PreToolUse" --arg decision "$decision" \
-            '{hookSpecificOutput:{hookEventName:$event,permissionDecision:$decision,permissionDecisionReason:$reason}}'
-    elif [ "$decision" = "allow" ]; then
-        printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"APort warning: policy would have denied this tool call. Policy: hook.input. Reason: oap.input_too_large."}}\n'
-    else
-        printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"APort denied this tool call. Policy: hook.input. Reason: oap.input_too_large."}}\n'
-    fi
+    aport_hook_build_response "$decision" "$notice" "$user_warning" "claude-code"
     exit 0
 }
 
@@ -128,20 +122,17 @@ safe_jq() {
     echo "$result"
 }
 
-# Deny helper: outputs Claude Code hookSpecificOutput JSON and exits 0.
+# Deny helper: outputs hookSpecificOutput JSON and exits 0.
 deny() {
     local reason="$1"
-    jq -n --arg reason "$reason" \
-        --arg event "PreToolUse" \
-        '{hookSpecificOutput:{hookEventName:$event,permissionDecision:"deny",permissionDecisionReason:$reason}}'
+    aport_hook_build_response "deny" "$reason" "" "claude-code"
     exit 0
 }
 
 warn_allow() {
     local reason="$1"
-    jq -n --arg reason "$reason" \
-        --arg event "PreToolUse" \
-        '{hookSpecificOutput:{hookEventName:$event,permissionDecision:"allow",permissionDecisionReason:$reason}}'
+    local user_warning="${2:-}"
+    aport_hook_build_response "allow" "$reason" "$user_warning" "claude-code"
     exit 0
 }
 
@@ -149,10 +140,11 @@ deny_or_warn() {
     local policy="$1"
     local code="${2:-oap.denied}"
     local message="${3:-}"
-    local notice
+    local notice user_warning
     if aport_hook_is_warn_mode; then
         notice="$(aport_format_guardrail_notice warn "$policy" "$code" "$message")"
-        warn_allow "$notice"
+        user_warning="$(aport_hook_format_user_warning "$policy" "$code" "$message")"
+        warn_allow "$notice" "$user_warning"
     fi
     notice="$(aport_format_guardrail_notice deny "$policy" "$code" "$message")"
     deny "$notice"

--- a/bin/aport-cursor-hook.sh
+++ b/bin/aport-cursor-hook.sh
@@ -58,25 +58,18 @@ if [ "${APORT_GUARDRAIL_MODE:-local}" = "api" ]; then
 fi
 
 emit_cursor_input_too_large() {
-    local notice
+    local decision="deny"
+    local notice user_warning
     if aport_hook_is_warn_mode; then
+        decision="allow"
         notice="$(aport_format_guardrail_notice warn hook.input oap.input_too_large "Hook payload exceeded ${APORT_HOOK_STDIN_MAX_BYTES} bytes.")"
-        if command -v jq > /dev/null 2>&1; then
-            jq -n -c --arg reason "$notice" \
-                '{permission:"allow",allowed:true,agentMessage:$reason,agent_message:$reason,user_message:$reason,reason:$reason}'
-        else
-            printf '{"permission":"allow","allowed":true,"agentMessage":"APort warning: policy would have denied this tool call. Policy: hook.input. Reason: oap.input_too_large.","agent_message":"APort warning: policy would have denied this tool call. Policy: hook.input. Reason: oap.input_too_large.","user_message":"APort warning: policy would have denied this tool call. Policy: hook.input. Reason: oap.input_too_large.","reason":"APort warning: policy would have denied this tool call. Policy: hook.input. Reason: oap.input_too_large."}\n'
-        fi
+        user_warning="$(aport_hook_format_user_warning hook.input oap.input_too_large "Hook payload exceeded ${APORT_HOOK_STDIN_MAX_BYTES} bytes.")"
+        aport_hook_build_response "$decision" "$notice" "$user_warning" "cursor"
         exit 0
     fi
 
     notice="$(aport_format_guardrail_notice deny hook.input oap.input_too_large "Hook payload exceeded ${APORT_HOOK_STDIN_MAX_BYTES} bytes.")"
-    if command -v jq > /dev/null 2>&1; then
-        jq -n -c --arg reason "$notice" \
-            '{permission:"deny",allowed:false,agentMessage:$reason,agent_message:$reason,user_message:$reason,reason:$reason}'
-    else
-        printf '{"permission":"deny","allowed":false,"agentMessage":"APort denied this tool call. Policy: hook.input. Reason: oap.input_too_large.","agent_message":"APort denied this tool call. Policy: hook.input. Reason: oap.input_too_large.","user_message":"APort denied this tool call. Policy: hook.input. Reason: oap.input_too_large.","reason":"APort denied this tool call. Policy: hook.input. Reason: oap.input_too_large."}\n'
-    fi
+    aport_hook_build_response "$decision" "$notice" "" "cursor"
     exit 2
 }
 
@@ -99,18 +92,17 @@ if ! command -v jq &> /dev/null; then
     exit 2
 fi
 
-# Deny helper: outputs Cursor-format JSON and exits 2
+# Deny helper: outputs hook response JSON and exits 2
 deny() {
     local reason="$1"
-    jq -n -c --arg reason "$reason" \
-        '{permission:"deny",allowed:false,agentMessage:$reason,agent_message:$reason,user_message:$reason,reason:$reason}'
+    aport_hook_build_response "deny" "$reason" "" "cursor"
     exit 2
 }
 
 warn_allow() {
     local reason="$1"
-    jq -n -c --arg reason "$reason" \
-        '{permission:"allow",allowed:true,agentMessage:$reason,agent_message:$reason,user_message:$reason,reason:$reason}'
+    local user_warning="${2:-}"
+    aport_hook_build_response "allow" "$reason" "$user_warning" "cursor"
     exit 0
 }
 
@@ -118,10 +110,11 @@ deny_or_warn() {
     local policy="$1"
     local code="${2:-oap.denied}"
     local message="${3:-}"
-    local notice
+    local notice user_warning
     if aport_hook_is_warn_mode; then
         notice="$(aport_format_guardrail_notice warn "$policy" "$code" "$message")"
-        warn_allow "$notice"
+        user_warning="$(aport_hook_format_user_warning "$policy" "$code" "$message")"
+        warn_allow "$notice" "$user_warning"
     fi
     notice="$(aport_format_guardrail_notice deny "$policy" "$code" "$message")"
     deny "$notice"

--- a/bin/github.sh
+++ b/bin/github.sh
@@ -391,6 +391,7 @@ else
     echo "  - Optional: run again with --policy to add a starter .aport/policy.yaml."
 fi
 echo "  - Commit the generated files and open or update a pull request."
+echo "  - Review the APort job summary in GitHub Actions after the first run."
 echo "  - The workflow runs in mode: $MODE and uses GitHub OIDC in auto/hosted mode; no broad APort API key is required."
 echo "  - Push detection watches: $PUSH_BRANCHES"
 if [[ -n "$PROTECTED_PATHS" ]]; then
@@ -401,7 +402,11 @@ if [[ -n "$BLOCK_PROTECTED_PATHS" ]]; then
 fi
 if [[ "$MODE" == "local-json" ]]; then
     echo "  - Local JSON passport path: $PASSPORT_PATH"
+elif [[ "$MODE" == "auto" ]]; then
+    echo "  - When ready to block risky changes, switch to mode: hosted and add branch protection for the APort check."
 fi
+echo "  - Docs: https://aport.io/quickstart/#github"
+echo "  - Team/Enterprise rollout: https://aport.io/pricing"
 echo ""
 
 if [[ -z "$workflow_written" && (-z "$WRITE_POLICY" || -z "$policy_written") ]]; then

--- a/bin/lib/framework-hook-paths.sh
+++ b/bin/lib/framework-hook-paths.sh
@@ -43,6 +43,7 @@ aport_hook_prepare_framework_paths() {
 
     selected_config_dir="${selected_config_dir:-$default_config_dir}"
     selected_config_dir="$(aport_hook_expand_path "$selected_config_dir")"
+    export APORT_HOOK_FRAMEWORK="$framework"
     export APORT_CONFIG_DIR="$selected_config_dir"
     export OPENCLAW_CONFIG_DIR="$selected_config_dir"
 

--- a/bin/lib/hook-runtime.sh
+++ b/bin/lib/hook-runtime.sh
@@ -213,3 +213,156 @@ aport_append_local_session_decision() {
     fi
     rm -f "$tmp" 2> /dev/null || true
 }
+
+aport_hook_detect_framework() {
+    local config_dir="${APORT_CONFIG_DIR:-${OPENCLAW_CONFIG_DIR:-}}"
+    local detected
+
+    if [ -n "${APORT_HOOK_FRAMEWORK:-}" ]; then
+        printf '%s' "$APORT_HOOK_FRAMEWORK"
+        return 0
+    fi
+
+    if command -v aport_hook_known_config_owner > /dev/null 2>&1; then
+        detected="$(aport_hook_known_config_owner "$config_dir")"
+    else
+        detected=""
+    fi
+    if [ -n "$detected" ]; then
+        printf '%s' "$detected"
+        return 0
+    fi
+
+    # Fallback: check common environment variables
+    if [ -n "${CURSOR_IDE:-}" ] || [ -n "${CURSOR_USER_DATA_DIR:-}" ]; then
+        printf 'cursor'
+    elif [ -n "${CLAUDE_CODE:-}" ] || [ "$config_dir" = "$HOME/.claude" ]; then
+        printf 'claude-code'
+    else
+        printf 'unknown'
+    fi
+}
+
+aport_hook_format_user_warning() {
+    local policy="$1"
+    local reason_code="${2:-oap.denied}"
+    local reason_message="${3:-}"
+    local reference
+
+    reason_code="$(aport_sanitize_display_text "$reason_code")"
+    reason_message="$(aport_sanitize_display_text "$reason_message")"
+    reference="$(aport_sanitize_display_text "$(aport_hook_policy_reference)")"
+
+    if [ -n "$reason_message" ] && [ "$reason_message" != "$reason_code" ]; then
+        printf '⚠️  APort Warning: This action would normally be blocked.\nPolicy: %s | Reason: %s\nDetail: %s\nReview: %s' "$policy" "$reason_code" "$reason_message" "$reference"
+    else
+        printf '⚠️  APort Warning: This action would normally be blocked.\nPolicy: %s | Reason: %s\nReview: %s' "$policy" "$reason_code" "$reference"
+    fi
+}
+
+aport_hook_json_escape() {
+    local value="${1:-}"
+
+    if command -v tr > /dev/null 2>&1; then
+        value="$(printf '%s' "$value" | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177')"
+    fi
+
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\t'/\\t}"
+    printf '%s' "$value"
+}
+
+aport_hook_build_response_claude_code() {
+    local decision="$1"
+    local reason="$2"
+    local user_warning="${3:-}"
+    local escaped_reason escaped_warning
+
+    if ! command -v jq > /dev/null 2>&1; then
+        escaped_reason="$(aport_hook_json_escape "$reason")"
+        escaped_warning="$(aport_hook_json_escape "$user_warning")"
+        if [ "$decision" = "allow" ] && [ -n "$user_warning" ]; then
+            printf '{"systemMessage":"%s","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"%s"}}\n' "$escaped_warning" "$escaped_reason"
+        elif [ "$decision" = "allow" ]; then
+            printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"%s"}}\n' "$escaped_reason"
+        else
+            printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$escaped_reason"
+        fi
+        return 0
+    fi
+
+    if [ "$decision" = "allow" ] && [ -n "$user_warning" ]; then
+        jq -n --arg reason "$reason" --arg warning "$user_warning" --arg event "PreToolUse" \
+            '{systemMessage:$warning,hookSpecificOutput:{hookEventName:$event,permissionDecision:"allow",permissionDecisionReason:$reason}}'
+    elif [ "$decision" = "allow" ]; then
+        jq -n --arg reason "$reason" --arg event "PreToolUse" \
+            '{hookSpecificOutput:{hookEventName:$event,permissionDecision:"allow",permissionDecisionReason:$reason}}'
+    else
+        jq -n --arg reason "$reason" --arg event "PreToolUse" \
+            '{hookSpecificOutput:{hookEventName:$event,permissionDecision:"deny",permissionDecisionReason:$reason}}'
+    fi
+}
+
+aport_hook_build_response_cursor() {
+    local decision="$1"
+    local reason="$2"
+    local user_warning="${3:-}"
+    local escaped_reason escaped_warning
+
+    # Cursor docs define warning text on deny responses; allow-response warning
+    # visibility varies by host surface. Keep these fields as best-effort context
+    # while audit logs remain the source of truth for report-only decisions.
+
+    if ! command -v jq > /dev/null 2>&1; then
+        escaped_reason="$(aport_hook_json_escape "$reason")"
+        escaped_warning="$(aport_hook_json_escape "$user_warning")"
+        if [ "$decision" = "allow" ] && [ -n "$user_warning" ]; then
+            # Best effort: some Cursor surfaces may not display allow warnings.
+            printf '{"permission":"allow","allowed":true,"agent_message":"%s","user_message":"%s","reason":"%s"}\n' "$escaped_warning" "$escaped_warning" "$escaped_reason"
+        elif [ "$decision" = "allow" ]; then
+            printf '{"permission":"allow","allowed":true,"reason":"%s"}\n' "$escaped_reason"
+        else
+            printf '{"permission":"deny","allowed":false,"agent_message":"%s","user_message":"%s","reason":"%s"}\n' "$escaped_reason" "$escaped_reason" "$escaped_reason"
+        fi
+        return 0
+    fi
+
+    if [ "$decision" = "allow" ] && [ -n "$user_warning" ]; then
+        # Best effort: some Cursor surfaces may not display allow warnings.
+        jq -n -c --arg reason "$reason" --arg warning "$user_warning" \
+            '{permission:"allow",allowed:true,agent_message:$warning,user_message:$warning,reason:$reason}'
+    elif [ "$decision" = "allow" ]; then
+        jq -n -c --arg reason "$reason" \
+            '{permission:"allow",allowed:true,reason:$reason}'
+    else
+        jq -n -c --arg reason "$reason" \
+            '{permission:"deny",allowed:false,agent_message:$reason,user_message:$reason,reason:$reason}'
+    fi
+}
+
+aport_hook_build_response() {
+    local decision="$1"
+    local reason="$2"
+    local user_warning="${3:-}"
+    local framework="${4:-}"
+
+    if [ -z "$framework" ]; then
+        framework="$(aport_hook_detect_framework)"
+    fi
+
+    case "$framework" in
+        claude-code)
+            aport_hook_build_response_claude_code "$decision" "$reason" "$user_warning"
+            ;;
+        cursor)
+            aport_hook_build_response_cursor "$decision" "$reason" "$user_warning"
+            ;;
+        *)
+            printf 'APort hook runtime error: unsupported hook response framework: %s\n' "$framework" >&2
+            return 64
+            ;;
+    esac
+}

--- a/bin/lib/hook-runtime.sh
+++ b/bin/lib/hook-runtime.sh
@@ -321,11 +321,11 @@ aport_hook_build_response_cursor() {
         escaped_warning="$(aport_hook_json_escape "$user_warning")"
         if [ "$decision" = "allow" ] && [ -n "$user_warning" ]; then
             # Best effort: some Cursor surfaces may not display allow warnings.
-            printf '{"permission":"allow","allowed":true,"agent_message":"%s","user_message":"%s","reason":"%s"}\n' "$escaped_warning" "$escaped_warning" "$escaped_reason"
+            printf '{"permission":"allow","allowed":true,"agentMessage":"%s","agent_message":"%s","user_message":"%s","reason":"%s"}\n' "$escaped_warning" "$escaped_warning" "$escaped_warning" "$escaped_reason"
         elif [ "$decision" = "allow" ]; then
             printf '{"permission":"allow","allowed":true,"reason":"%s"}\n' "$escaped_reason"
         else
-            printf '{"permission":"deny","allowed":false,"agent_message":"%s","user_message":"%s","reason":"%s"}\n' "$escaped_reason" "$escaped_reason" "$escaped_reason"
+            printf '{"permission":"deny","allowed":false,"agentMessage":"%s","agent_message":"%s","user_message":"%s","reason":"%s"}\n' "$escaped_reason" "$escaped_reason" "$escaped_reason" "$escaped_reason"
         fi
         return 0
     fi
@@ -333,13 +333,13 @@ aport_hook_build_response_cursor() {
     if [ "$decision" = "allow" ] && [ -n "$user_warning" ]; then
         # Best effort: some Cursor surfaces may not display allow warnings.
         jq -n -c --arg reason "$reason" --arg warning "$user_warning" \
-            '{permission:"allow",allowed:true,agent_message:$warning,user_message:$warning,reason:$reason}'
+            '{permission:"allow",allowed:true,agentMessage:$warning,agent_message:$warning,user_message:$warning,reason:$reason}'
     elif [ "$decision" = "allow" ]; then
         jq -n -c --arg reason "$reason" \
             '{permission:"allow",allowed:true,reason:$reason}'
     else
         jq -n -c --arg reason "$reason" \
-            '{permission:"deny",allowed:false,agent_message:$reason,user_message:$reason,reason:$reason}'
+            '{permission:"deny",allowed:false,agentMessage:$reason,agent_message:$reason,user_message:$reason,reason:$reason}'
     fi
 }
 

--- a/docs/ENTERPRISE_DEVICE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEVICE_DEPLOYMENT.md
@@ -49,7 +49,7 @@ Use `sudo -E` so the whole script runs with administrator permissions and receiv
 If `sudo -E` is restricted on the device, pass the variables through `sudo env`:
 
 ```bash
-curl -fsSL "https://api.aport.io/enterprise/scripts/deploy?version=1.0.29" | \
+curl -fsSL "https://api.aport.io/enterprise/scripts/deploy" | \
   sudo env \
     APORT_API_KEY="$APORT_API_KEY" \
     APORT_TEMPLATE_ID="$APORT_TEMPLATE_ID" \

--- a/docs/FAQ_SECURITY_SCANNERS.md
+++ b/docs/FAQ_SECURITY_SCANNERS.md
@@ -352,8 +352,8 @@ We're planning a security audit by a reputable firm (Trail of Bits, NCC Group, o
 **With APort:**
 - ✅ Every tool call is authorized BEFORE it runs
 - ✅ Malicious actions are blocked deterministically
-- ✅ Cryptographically signed audit logs
-- ✅ Compliance-ready (SOC 2, GDPR, HIPAA)
+- ✅ Hosted/API decisions are cryptographically signed
+- ✅ Decision records support SOC 2, GDPR, HIPAA, and similar evidence workflows
 
 **APort is the enforcement layer. Nothing runs without authorization.**
 

--- a/docs/FRAMEWORK_ROADMAP.md
+++ b/docs/FRAMEWORK_ROADMAP.md
@@ -1,6 +1,6 @@
 # Supported surfaces roadmap
 
-Public developer view of supported repository and runtime surfaces. Details per framework: [docs/frameworks/](frameworks/). **What’s production-ready:** [DEPLOYMENT_READINESS.md](DEPLOYMENT_READINESS.md).
+Public developer view of supported repository and runtime surfaces. Details per framework: [docs/frameworks/](frameworks/). Release gates and publishing steps live in [RELEASE.md](RELEASE.md).
 
 ## Supported surfaces
 

--- a/docs/GITHUB_PROTECTION.md
+++ b/docs/GITHUB_PROTECTION.md
@@ -94,8 +94,9 @@ For repository workflows, the passport should include only the capabilities that
 
 Common capabilities:
 
-- `repo.pr.create` for PR creation/update and push-style checks.
+- `repo.pr.create` for PR creation/update checks.
 - `repo.merge` for merge checks.
+- `repo.push` for direct push checks on protected branches. Free GitHub OIDC passports omit this by default, so ordinary direct pushes are denied unless the repository intentionally authorizes them.
 - `repo.release` only when directly invoking `code.release.publish.v1` for release publishing checks. Legacy local passports with `release` are still accepted as an alias.
 
 Common limits:

--- a/docs/HOSTED_PASSPORT_SETUP.md
+++ b/docs/HOSTED_PASSPORT_SETUP.md
@@ -43,7 +43,7 @@ When prompted for passport setup, choose option `1`:
 2. `Use existing hosted passport ID` — paste an existing `agent_id`.
 3. `Create local passport file` — offline/local JSON passport.
 
-The installer creates a passport, creates a narrow setup key, and configures the plugin to use hosted verification.
+The installer creates a passport, creates a narrow setup key, and configures the framework hook/plugin to use hosted verification.
 
 Non-interactive hosted setup uses the same dispatcher:
 
@@ -72,39 +72,43 @@ npx @aporthq/aport-agent-guardrails
 
 When prompted for passport, create a hosted passport or paste an existing `agent_id`. The config directory defaults to the selected framework's APort directory. API mode is required for hosted passports.
 
-The OpenClaw-specific examples below show plugin configuration details. Claude Code and Cursor use their own framework hook files, but the hosted-passport model is the same: the hook stores `agent_id`, sends action context to APort Verify, and receives an allow/deny decision.
+**Step 3: Restart or run the target framework**
 
-**Step 3: Start OpenClaw**
+- **Claude Code:** restart Claude Code so `~/.claude/settings.json` is loaded.
+- **Cursor:** reload the Cursor window or restart Cursor so `.cursor/hooks.json` is loaded.
+- **OpenClaw:** start or restart the gateway:
 
-```bash
-openclaw gateway start --config ~/.openclaw/config.yaml
-```
+  ```bash
+  openclaw gateway start --config ~/.openclaw/config.yaml
+  ```
 
-**Done!** The plugin will fetch your passport from APort API on every tool call.
+- **LangChain / CrewAI:** install the Python adapter and register the callback/hook from the framework doc.
+
+**Done.** The installed hook/plugin sends action context to APort Verify and receives an allow/deny decision using the hosted `agent_id`.
 
 ---
 
 ## How It Works (Hosted Passport)
 
 ```
-User → OpenClaw: "Create a file"
+User → Framework: "Create a file"
          ↓
-    OpenClaw: Tool call → before_tool_call hook
+ Framework: Tool call → hook/callback/plugin
          ↓
- APort Plugin: Reads config → sees agent_id (no local passport file)
+ APort Guardrail: Reads config → sees agent_id (no local passport file)
          ↓
- APort Plugin: POST to api.aport.io/api/verify/policy/system.command.execute.v1
-                Body: { "context": { "agent_id": "ap_abc123...", "command": "touch test.txt" } }
+ APort Guardrail: POST to api.aport.io/api/verify/policy/system.command.execute.v1
+                  Body: { "context": { "agent_id": "ap_abc123...", "command": "touch test.txt" } }
          ↓
     APort API: Fetches passport from registry by agent_id
          ↓
     APort API: Evaluates policy → Returns ALLOW/DENY
          ↓
- APort Plugin: ✅ ALLOW → Tool runs
-              ❌ DENY → Tool blocked
+ APort Guardrail: ✅ ALLOW → Tool runs
+                 ❌ DENY → Tool blocked
 ```
 
-**Key Point:** Your passport stays in APort's registry. The plugin sends `agent_id` + context, API fetches passport, evaluates policy, returns decision. **No passport file stored locally.**
+**Key Point:** Your passport stays in APort's registry. The guardrail sends `agent_id` + context, API fetches passport, evaluates policy, returns decision. **No passport file stored locally.**
 
 ---
 
@@ -367,6 +371,8 @@ A: With `failClosed: true` (default), all tool calls are blocked. Set `failClose
 
 **Q: How do I roll out without blocking developers?**
 A: Keep `failClosed: true`, but set `enforcementMode: warn` or run `npx @aporthq/aport-agent-guardrails mode <framework> --enforcement=warn`. This records the original deny decision while allowing the framework action to continue. Switch back to `--enforcement=enforce` when the passport is tuned.
+
+Claude Code surfaces warn-mode decisions with a visible `systemMessage`. Cursor returns warning fields as best-effort context but may not display allow warnings in the UI; use the audit log or `bin/aport-status.sh` to inspect report-only decisions.
 
 **Q: Can I create multiple hosted passports?**
 A: Yes! Free tier: 1 passport. Beta/Pro: Unlimited. Each passport has unique `agent_id`.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -77,6 +77,11 @@ npx @aporthq/aport-agent-guardrails mode cursor --enforcement=enforce
 The `mode` command preserves the existing hosted passport, setup key, API URL,
 and local passport path. It only changes mode/enforcement settings.
 
+Warn-mode visibility depends on the host. Claude Code shows an APort `systemMessage`
+warning. Cursor returns warning fields as best-effort context but may not display
+allow warnings in the UI, so check `bin/aport-status.sh` or the audit log for the
+recorded report-only decision.
+
 ## 4. Enterprise device rollout
 
 For IT-managed fleets, use the bundled deploy/enforce/uninstall scripts:

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 | [GITHUB_PROTECTION.md](GITHUB_PROTECTION.md) | GitHub Actions report/enforce setup for repository provenance, merge/push evidence, and related local release-policy checks |
 | [QUICKSTART.md](QUICKSTART.md) | GitHub-first setup, runtime hook setup, and hosted/local passport options |
 | [**HOSTED_PASSPORT_SETUP.md**](HOSTED_PASSPORT_SETUP.md) | **Use passport from aport.io** — create hosted during setup or pass an existing `agent_id` |
+| [OAP Decisions vs Harness Enforcement](https://github.com/aporthq/agent-passport/blob/main/docs/DECISION-VS-ENFORCEMENT.md) | Canonical model for signed OAP allow/deny decisions versus local warn/report-only enforcement disposition |
 | [ENTERPRISE_DEVICE_DEPLOYMENT.md](ENTERPRISE_DEVICE_DEPLOYMENT.md) | IT-managed deploy, enforce, and uninstall scripts |
 | [QUICKSTART_OPENCLAW_PLUGIN.md](QUICKSTART_OPENCLAW_PLUGIN.md) | OpenClaw plugin setup for OpenClaw-specific deployments |
 | [OPENCLAW_LOCAL_INTEGRATION.md](OPENCLAW_LOCAL_INTEGRATION.md) | Full OpenClaw setup: API, passport, policies, Python example |
@@ -22,5 +23,5 @@
 | Doc | Purpose |
 |-----|---------|
 | [RELEASE.md](RELEASE.md) | Versioning, changelog, tagging, and publish process |
-| [DEPLOYMENT_READINESS.md](DEPLOYMENT_READINESS.md) | Release-readiness checklist and supported framework status |
+| [FRAMEWORK_ROADMAP.md](FRAMEWORK_ROADMAP.md) | Supported repository/runtime surfaces and framework status |
 | [SECURITY_MODEL.md](SECURITY_MODEL.md) | Threat model, fail-closed behavior, and deployment guidance |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release process and version policy
 
-**Current release:** 1.0.31 (see [CHANGELOG.md](../CHANGELOG.md)).
+**Current release:** 1.0.32 (see [CHANGELOG.md](../CHANGELOG.md)).
 
 We keep **one version number** across all published packages (Node core, Python core, and every framework adapter). That avoids “core is 1.2 but CLI is 0.9” and keeps the story simple for users and support.
 

--- a/docs/frameworks/claude-code.md
+++ b/docs/frameworks/claude-code.md
@@ -9,7 +9,7 @@ Claude Code's **PreToolUse** hook runs as a separate process before each tool ex
 ## How it works
 
 - **Settings file:** Claude Code uses `~/.claude/settings.json` (user-level) or `.claude/settings.json` (project-level). This is **not** `~/.cursor/hooks.json` — different location and JSON structure.
-- **PreToolUse hook:** The hook receives JSON on stdin with `tool_name` and `tool_input`, runs the APort guardrail, and outputs Claude Code's exact structured deny format on stdout when blocking: `hookSpecificOutput.permissionDecision: "deny"`. Claude Code reads structured hook JSON from stdout on exit 0; exit 2 is only for stderr-based blocking.
+- **PreToolUse hook:** The hook receives JSON on stdin with `tool_name` and `tool_input`, runs the APort guardrail, and outputs Claude Code's exact structured format on stdout. Enforce mode blocks with `hookSpecificOutput.permissionDecision: "deny"`. Warn/report-only mode returns `permissionDecision: "allow"` plus a `systemMessage` warning so the action can continue while the user sees that APort would have blocked it. Claude Code reads structured hook JSON from stdout on exit 0; exit 2 is only for stderr-based blocking.
 - **Hook script:** `bin/aport-claude-code-hook.sh` — maps all Claude Code tool names (Bash, Read, Write, Edit, MultiEdit, Glob, LS, Grep, WebSearch, WebFetch, Browser, TodoRead, TodoWrite, Task, MCP tools) to APort policies and calls the core evaluator.
 
 ---
@@ -62,6 +62,8 @@ Default enforcement is `enforce` (fail-closed). To roll out without blocking dev
 ```bash
 npx @aporthq/aport-agent-guardrails claude-code --enforcement=warn
 ```
+
+In warn mode, Claude Code receives an allow decision plus a visible APort warning that includes the policy, reason code, and the hosted passport or local passport-file reference to update.
 
 To change enforcement later without creating a new passport or reinstalling the hook:
 

--- a/docs/frameworks/crewai.md
+++ b/docs/frameworks/crewai.md
@@ -138,6 +138,11 @@ The provider and adapter read the standard APort config:
 - `enforcement_mode: enforce` to block by default, or `warn` for explicit report-only rollout
 - `audit_log` to enable or disable audit logging
 
+In compatibility mode, warn mode lets CrewAI continue and prints an APort warning
+with the tool, policy, reason code, reason detail, and the hosted passport or
+local passport file to review. In native provider mode, warn-mode decisions are
+returned as provider metadata for the host/runtime to surface.
+
 With the default bootstrap, you usually do not need to set `guardrail_script`
 manually because the local runtime is installed under the framework config
 directory.

--- a/docs/frameworks/cursor.md
+++ b/docs/frameworks/cursor.md
@@ -27,7 +27,7 @@ For Cursor, you almost always use **Guardrails (CLI)** once to install the hook;
 - **Cursor CLI coverage:** Cursor CLI hook coverage has changed over time and may lag the IDE. APort installs the supported hook entries and uses fail-closed `deny` for enforcement, but direct coverage depends on the Cursor version and which hook events that version emits.
 - **Claude Code:** Uses `~/.claude/settings.json` with a **different** output format (`hookSpecificOutput.permissionDecision`). Use the **dedicated Claude Code integration** instead of this Cursor hook — see [claude-code.md](./claude-code.md).
 
-Our script accepts Cursor payloads and a small set of legacy tool payloads (e.g. `command`, or `tool`/`input`), maps to the matching APort policy, calls the guardrail evaluator, and returns Cursor-compatible JSON with `permission`, `agent_message`, and `user_message`.
+Our script accepts Cursor payloads and a small set of legacy tool payloads (e.g. `command`, or `tool`/`input`), maps to the matching APort policy, calls the guardrail evaluator, and returns Cursor-compatible JSON with `permission`, `agent_message`, and `user_message` where the host consumes those fields.
 
 **Hook script path:** The hook script (`aport-cursor-hook.sh`) resolves `bin/aport-guardrail-bash.sh` relative to its own directory (script dir → parent = package root). When you install via **npx**, the installer writes the path to the script inside the npx cache (e.g. `…/node_modules/@aporthq/aport-agent-guardrails/bin/aport-cursor-hook.sh`), so the guardrail script is found at `…/bin/aport-guardrail-bash.sh`. If you copy the hook script elsewhere, ensure `bin/aport-guardrail-bash.sh` exists at the same relative location or set `APORT_GUARDRAIL_SCRIPT` (or equivalent) so the hook can find the evaluator.
 
@@ -46,6 +46,8 @@ Default enforcement is `enforce` (fail-closed). To roll out in report-only mode,
 ```bash
 npx @aporthq/aport-agent-guardrails cursor --enforcement=warn
 ```
+
+In warn mode, APort still evaluates and records the original deny decision, then returns `permission: "allow"` so Cursor can continue. Cursor's hook UI is most reliable at surfacing messages on deny; allow warnings are returned in the JSON as best-effort context, but the audit log and `bin/aport-status.sh` are the source of truth for report-only decisions.
 
 To change enforcement later without creating a new passport or reinstalling hooks:
 

--- a/docs/frameworks/langchain.md
+++ b/docs/frameworks/langchain.md
@@ -59,6 +59,10 @@ Default enforcement is fail-closed. For rollout/report-only mode:
 APortCallback(enforcement_mode="warn")
 ```
 
+Warn mode lets the tool continue and prints an APort warning with the tool,
+policy, reason code, reason detail, and the hosted passport or local passport
+file to review.
+
 **Node:** Add `APortGuardrailCallback` to your chain/agent callbacks. Config is read from `~/.aport/langchain/` or `.aport/config.yaml`.
 
 ```ts

--- a/extensions/openclaw-aport/CHANGELOG.md
+++ b/extensions/openclaw-aport/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - APort OpenClaw Plugin
 
+## 1.0.32
+
+### Patch Changes
+
+- Report hosted runtime enforcement metadata to APort while keeping local/offline evaluation unchanged.
+
 ## 1.0.31
 
 ### Patch Changes

--- a/extensions/openclaw-aport/api-client.js
+++ b/extensions/openclaw-aport/api-client.js
@@ -1,11 +1,13 @@
-export async function verifyViaApi({ apiUrl, apiKey, policyName, context, passport, agentId, signal }) {
+export async function verifyViaApi({ apiUrl, apiKey, policyName, context, passport, agentId, signal, runtime }) {
   const baseUrl = String(apiUrl || "https://api.aport.io").replace(/\/$/, "");
   const headers = { "Content-Type": "application/json" };
   if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
 
-  const body = agentId
-    ? JSON.stringify({ context: { agent_id: agentId, ...context } })
-    : JSON.stringify({ passport, context });
+  const payload = agentId
+    ? { context: { agent_id: agentId, ...context } }
+    : { passport, context };
+  if (runtime) payload.runtime = runtime;
+  const body = JSON.stringify(payload);
 
   const response = await fetch(`${baseUrl}/api/verify/policy/${policyName}`, {
     method: "POST",

--- a/extensions/openclaw-aport/index.js
+++ b/extensions/openclaw-aport/index.js
@@ -127,6 +127,7 @@ export default definePluginEntry({
                 passport: agentId ? null : JSON.parse(await readFile(passportFile, "utf8")),
                 agentId,
                 signal: hookContext?.abortSignal,
+                runtime: buildRuntimeMetadata(enforcement),
               })
             : evaluateLocalDecision({
                 policyName: effectivePolicyName,
@@ -346,6 +347,14 @@ function normalizeEnforcementMode(value) {
   const normalized = String(value || "enforce").toLowerCase().replace(/_/g, "-");
   if (["warn", "report-only", "audit-only", "observe", "observation"].includes(normalized)) return "warn";
   return "enforce";
+}
+
+function buildRuntimeMetadata(enforcement) {
+  return {
+    enforcement_mode: enforcement === "warn" ? "warn" : "enforce",
+    enforced_by: "@aporthq/openclaw-aport",
+    harness: "openclaw",
+  };
 }
 
 function sanitizeDisplayText(value) {

--- a/extensions/openclaw-aport/openclaw.plugin.json
+++ b/extensions/openclaw-aport/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "openclaw-aport",
   "name": "APort Guardrails",
   "description": "Deterministic pre-action authorization via APort policy enforcement. Registers before_tool_call to block disallowed tools.",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "activation": {
     "onStartup": true,
     "onCapabilities": [

--- a/extensions/openclaw-aport/package-lock.json
+++ b/extensions/openclaw-aport/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^18.0.0",

--- a/extensions/openclaw-aport/package.json
+++ b/extensions/openclaw-aport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/openclaw-aport",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "OpenClaw plugin for deterministic pre-action authorization via APort guardrails",
   "main": "index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aporthq/aport-agent-guardrails",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -30,7 +30,7 @@
     },
     "extensions/openclaw-aport": {
       "name": "@aporthq/openclaw-aport",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -15078,10 +15078,10 @@
     },
     "packages/claude-code": {
       "name": "@aporthq/aport-agent-guardrails-claude-code",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
       },
       "bin": {
         "aport-agent-guardrails-claude-code": "bin/install"
@@ -15093,7 +15093,7 @@
     },
     "packages/core": {
       "name": "@aporthq/aport-agent-guardrails-core",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -15112,10 +15112,10 @@
     },
     "packages/crewai": {
       "name": "@aporthq/aport-agent-guardrails-crewai",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
       },
       "bin": {
         "aport-agent-guardrails-crewai": "bin/install"
@@ -15127,10 +15127,10 @@
     },
     "packages/cursor": {
       "name": "@aporthq/aport-agent-guardrails-cursor",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
       },
       "bin": {
         "aport-agent-guardrails-cursor": "bin/install"
@@ -15142,7 +15142,7 @@
     },
     "packages/deprecated-agent-guardrails": {
       "name": "@aporthq/agent-guardrails",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15159,10 +15159,10 @@
     },
     "packages/langchain": {
       "name": "@aporthq/aport-agent-guardrails-langchain",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.31",
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.32",
         "@langchain/core": "^0.3.0"
       },
       "bin": {
@@ -15178,10 +15178,10 @@
     },
     "packages/n8n": {
       "name": "@aporthq/aport-agent-guardrails-n8n",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+        "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
       },
       "bin": {
         "aport-agent-guardrails-n8n": "bin/install"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "APort Repository Guard and pre-action authorization guardrails for GitHub, Claude Code, Cursor, OpenClaw, LangChain, CrewAI, DeerFlow, and n8n",
   "workspaces": [
     "packages/*",

--- a/packages/claude-code/CHANGELOG.md
+++ b/packages/claude-code/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-claude-code
 
+## 1.0.32
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.32
+
 ## 1.0.31
 
 ### Patch Changes

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-claude-code",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "APort guardrails for Claude Code — PreToolUse hook",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-core
 
+## 1.0.32
+
+### Patch Changes
+
+- Make report-only guardrail warnings safer and more actionable across framework hooks.
+- Report hosted runtime enforcement metadata to APort so signed deny decisions can be reconciled with framework-level warn mode in the dashboard.
+
 ## 1.0.31
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-core",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Core evaluator, passport, and config for APort agent guardrails (shared across frameworks)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/core/evaluator.test.ts
+++ b/packages/core/src/core/evaluator.test.ts
@@ -161,4 +161,47 @@ describe('Evaluator', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it('lets adapter overrides drive hosted runtime enforcement metadata', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({ decision: { allow: true, reasons: [] } }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const configPath = path.join(tmpDir, 'config.yaml');
+      fs.writeFileSync(
+        configPath,
+        'mode: api\nframework: langchain\nagent_id: ap_1234567890abcdef1234567890abcdef\nenforcement_mode: enforce\n',
+        'utf8'
+      );
+
+      const evaluator = new Evaluator(configPath, 'langchain', {
+        enforcementMode: 'warn',
+        harness: 'langchain',
+      });
+      await evaluator.verify(
+        { agent_id: 'ap_1234567890abcdef1234567890abcdef' },
+        { capability: 'system.command.execute.v1' },
+        { tool: 'exec.run', command: 'ls' }
+      );
+
+      const body = capturedBody as { runtime?: unknown } | null;
+      expect(body?.runtime).toEqual({
+        enforcement_mode: 'warn',
+        enforced_by: '@aporthq/aport-agent-guardrails',
+        harness: 'langchain',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/core/src/core/evaluator.test.ts
+++ b/packages/core/src/core/evaluator.test.ts
@@ -121,4 +121,44 @@ describe('Evaluator', () => {
       else delete process.env.HOME;
     }
   });
+
+  it('sends runtime enforcement metadata only on API verification requests', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({ decision: { allow: true, reasons: [] } }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const configPath = path.join(tmpDir, 'config.yaml');
+      fs.writeFileSync(
+        configPath,
+        'mode: api\nframework: langchain\nagent_id: ap_1234567890abcdef1234567890abcdef\nenforcement_mode: warn\n',
+        'utf8'
+      );
+
+      const evaluator = new Evaluator(configPath, 'langchain');
+      await evaluator.verify(
+        { agent_id: 'ap_1234567890abcdef1234567890abcdef' },
+        { capability: 'system.command.execute.v1' },
+        { tool: 'exec.run', command: 'ls' }
+      );
+
+      const body = capturedBody as { runtime?: unknown } | null;
+      expect(body?.runtime).toEqual({
+        enforcement_mode: 'warn',
+        enforced_by: '@aporthq/aport-agent-guardrails',
+        harness: 'langchain',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/core/src/core/evaluator.ts
+++ b/packages/core/src/core/evaluator.ts
@@ -39,6 +39,14 @@ export interface Decision {
   reasons?: Array<{ code?: string; message?: string }>;
 }
 
+type RuntimeEnforcementMode = 'enforce' | 'warn';
+
+interface RuntimeMetadata {
+  enforcement_mode: RuntimeEnforcementMode;
+  enforced_by: string;
+  harness: string;
+}
+
 export interface VerifyRequest {
   passport: Passport;
   policy: PolicyPack;
@@ -157,6 +165,43 @@ function isFullPolicyPack(p: PolicyPack | undefined): boolean {
   return Boolean(p.id && p.requires_capabilities !== undefined);
 }
 
+function normalizeRuntimeString(value: unknown, fallback: string): string {
+  const normalized =
+    typeof value === 'string'
+      ? value
+          .replace(/[\u0000-\u001f\u007f]/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim()
+      : '';
+  return (normalized || fallback).slice(0, 80);
+}
+
+function resolveRuntimeEnforcementMode(config: Config): RuntimeEnforcementMode {
+  const raw = String(
+    config.enforcement_mode ??
+      config.enforcementMode ??
+      process.env.APORT_ENFORCEMENT_MODE ??
+      process.env.APORT_ENFORCEMENT ??
+      process.env.APORT_GUARDRAIL_ENFORCEMENT ??
+      'enforce'
+  )
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-');
+
+  return ['warn', 'report-only', 'audit-only', 'observe', 'observation'].includes(raw)
+    ? 'warn'
+    : 'enforce';
+}
+
+function buildRuntimeMetadata(config: Config, fallbackHarness: string): RuntimeMetadata {
+  return {
+    enforcement_mode: resolveRuntimeEnforcementMode(config),
+    enforced_by: '@aporthq/aport-agent-guardrails',
+    harness: normalizeRuntimeString(config.framework, fallbackHarness),
+  };
+}
+
 async function callApi(
   apiUrl: string,
   packId: string,
@@ -168,6 +213,7 @@ async function callApi(
     apiKey?: string;
     verifySsl?: boolean;
     failOpenOnApiError?: boolean;
+    runtime?: RuntimeMetadata;
   }
 ): Promise<Decision> {
   const base = apiUrl.replace(/\/$/, '');
@@ -180,6 +226,7 @@ async function callApi(
   const body: Record<string, unknown> = { context: bodyContext };
   if (options.passport) body.passport = options.passport;
   if (options.policyPack && isFullPolicyPack(options.policyPack)) body.policy = options.policyPack;
+  if (options.runtime) body.runtime = options.runtime;
   if (!options.agentId && !options.passport) {
     return { allow: false, reasons: [{ code: 'oap.api_error', message: 'Either agent_id or passport required' }] };
   }
@@ -311,8 +358,9 @@ export class Evaluator {
         }
       }
       const failOpenOnApiError = Boolean(config.fail_open_on_api_error ?? process.env.APORT_FAIL_OPEN_ON_API_ERROR === '1');
+      const runtime = buildRuntimeMetadata(config, this.framework);
       if (agentId) {
-        const decision = await callApi(apiUrl, packId, ctx, { agentId, policyPack: isFullPolicyPack(policy) ? policy : undefined, apiKey, verifySsl: verifySslOverride, failOpenOnApiError });
+        const decision = await callApi(apiUrl, packId, ctx, { agentId, policyPack: isFullPolicyPack(policy) ? policy : undefined, apiKey, verifySsl: verifySslOverride, failOpenOnApiError, runtime });
         this.auditLog(config, toolName, packId, decision, ctx);
         return decision;
       }
@@ -323,6 +371,7 @@ export class Evaluator {
           apiKey,
           verifySsl: verifySslOverride,
           failOpenOnApiError,
+          runtime,
         });
         this.auditLog(config, toolName, packId, decision, ctx);
         return decision;
@@ -376,6 +425,7 @@ export class Evaluator {
         }
       }
       if (agentId || passportBody) {
+        const runtime = buildRuntimeMetadata(config, this.framework);
         const pathId = isFullPolicyPack(policy) ? IN_BODY_PACK_ID : packId;
         const body: Record<string, unknown> = {
           context: {
@@ -386,6 +436,7 @@ export class Evaluator {
         };
         if (passportBody) body.passport = passportBody;
         if (isFullPolicyPack(policy)) body.policy = policy;
+        body.runtime = runtime;
         const url = `${apiUrl.replace(/\/$/, '')}/api/verify/policy/${pathId}`;
         const headers: Record<string, string> = { 'Content-Type': 'application/json' };
         if (apiKey) headers.Authorization = `Bearer ${apiKey}`;

--- a/packages/core/src/core/evaluator.ts
+++ b/packages/core/src/core/evaluator.ts
@@ -47,6 +47,12 @@ interface RuntimeMetadata {
   harness: string;
 }
 
+export interface EvaluatorRuntimeOptions {
+  enforcementMode?: unknown;
+  enforcement_mode?: unknown;
+  harness?: unknown;
+}
+
 export interface VerifyRequest {
   passport: Passport;
   policy: PolicyPack;
@@ -176,9 +182,13 @@ function normalizeRuntimeString(value: unknown, fallback: string): string {
   return (normalized || fallback).slice(0, 80);
 }
 
-function resolveRuntimeEnforcementMode(config: Config): RuntimeEnforcementMode {
+function resolveRuntimeEnforcementMode(
+  config: Config,
+  override?: unknown
+): RuntimeEnforcementMode {
   const raw = String(
-    config.enforcement_mode ??
+    override ??
+      config.enforcement_mode ??
       config.enforcementMode ??
       process.env.APORT_ENFORCEMENT_MODE ??
       process.env.APORT_ENFORCEMENT ??
@@ -194,11 +204,21 @@ function resolveRuntimeEnforcementMode(config: Config): RuntimeEnforcementMode {
     : 'enforce';
 }
 
-function buildRuntimeMetadata(config: Config, fallbackHarness: string): RuntimeMetadata {
+function buildRuntimeMetadata(
+  config: Config,
+  fallbackHarness: string,
+  runtimeOptions: EvaluatorRuntimeOptions = {}
+): RuntimeMetadata {
   return {
-    enforcement_mode: resolveRuntimeEnforcementMode(config),
+    enforcement_mode: resolveRuntimeEnforcementMode(
+      config,
+      runtimeOptions.enforcementMode ?? runtimeOptions.enforcement_mode
+    ),
     enforced_by: '@aporthq/aport-agent-guardrails',
-    harness: normalizeRuntimeString(config.framework, fallbackHarness),
+    harness: normalizeRuntimeString(
+      runtimeOptions.harness ?? config.framework,
+      fallbackHarness
+    ),
   };
 }
 
@@ -276,11 +296,17 @@ async function callApi(
 export class Evaluator {
   private configPath: string | null;
   private framework: string;
+  private runtimeOptions: EvaluatorRuntimeOptions;
   private cachedConfig: Config | null = null;
 
-  constructor(configPath?: string | null, framework: string = 'langchain') {
+  constructor(
+    configPath?: string | null,
+    framework: string = 'langchain',
+    runtimeOptions: EvaluatorRuntimeOptions = {}
+  ) {
     this.configPath = configPath ?? null;
     this.framework = framework;
+    this.runtimeOptions = runtimeOptions;
   }
 
   /** Resolve the effective config path used for this evaluator (for audit log path resolution). */
@@ -358,7 +384,11 @@ export class Evaluator {
         }
       }
       const failOpenOnApiError = Boolean(config.fail_open_on_api_error ?? process.env.APORT_FAIL_OPEN_ON_API_ERROR === '1');
-      const runtime = buildRuntimeMetadata(config, this.framework);
+      const runtime = buildRuntimeMetadata(
+        config,
+        this.framework,
+        this.runtimeOptions
+      );
       if (agentId) {
         const decision = await callApi(apiUrl, packId, ctx, { agentId, policyPack: isFullPolicyPack(policy) ? policy : undefined, apiKey, verifySsl: verifySslOverride, failOpenOnApiError, runtime });
         this.auditLog(config, toolName, packId, decision, ctx);
@@ -425,7 +455,11 @@ export class Evaluator {
         }
       }
       if (agentId || passportBody) {
-        const runtime = buildRuntimeMetadata(config, this.framework);
+        const runtime = buildRuntimeMetadata(
+          config,
+          this.framework,
+          this.runtimeOptions
+        );
         const pathId = isFullPolicyPack(policy) ? IN_BODY_PACK_ID : packId;
         const body: Record<string, unknown> = {
           context: {

--- a/packages/core/src/providers/oap-guardrail-provider.test.ts
+++ b/packages/core/src/providers/oap-guardrail-provider.test.ts
@@ -74,4 +74,52 @@ describe("OAPGuardrailProvider", () => {
       originalAllow: false,
     });
   });
+
+  it("reports explicit warn mode to hosted runtime metadata", async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () =>
+          JSON.stringify({
+            decision: {
+              allow: false,
+              reasons: [{ code: "oap.denied", message: "blocked" }],
+            },
+          }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const provider = new OAPGuardrailProvider({
+        framework: "generic",
+        enforcementMode: "warn",
+      });
+      (provider as any).evaluator.cachedConfig = {
+        mode: "api",
+        agent_id: "ap_1234567890abcdef1234567890abcdef",
+        enforcement_mode: "enforce",
+      };
+
+      const decision = await provider.evaluate(makeRequest("bash", { command: "sudo ls" }));
+
+      expect(decision.allow).toBe(true);
+      expect(decision.metadata).toMatchObject({
+        enforcementMode: "warn",
+        originalAllow: false,
+      });
+      const body = capturedBody as { runtime?: unknown } | null;
+      expect(body?.runtime).toMatchObject({
+        enforcement_mode: "warn",
+        harness: "generic",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/core/src/providers/oap-guardrail-provider.ts
+++ b/packages/core/src/providers/oap-guardrail-provider.ts
@@ -70,7 +70,10 @@ export class OAPGuardrailProvider {
         loadedConfig.enforcementMode ??
         loadedConfig.enforcement_mode,
     );
-    this.evaluator = new Evaluator(configPath, framework);
+    this.evaluator = new Evaluator(configPath, framework, {
+      enforcementMode: this.enforcementMode,
+      harness: framework,
+    });
   }
 
   /**

--- a/packages/crewai/CHANGELOG.md
+++ b/packages/crewai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-crewai
 
+## 1.0.32
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.32
+
 ## 1.0.31
 
 ### Patch Changes

--- a/packages/crewai/package.json
+++ b/packages/crewai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-crewai",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "APort guardrails for CrewAI — task decorator / middleware",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/crewai/src/middleware.ts
+++ b/packages/crewai/src/middleware.ts
@@ -19,9 +19,19 @@ export interface BeforeToolCallContext {
 let _crewaiEvaluator: Evaluator | null = null;
 let _crewaiEnforcementMode: "enforce" | "warn" | null = null;
 
+type RuntimeAwareEvaluatorConstructor = new (
+  configPath?: string | null,
+  framework?: string,
+  runtimeOptions?: { enforcementMode?: string; harness?: string }
+) => Evaluator;
+
 function getCrewaiEvaluator(): Evaluator {
   if (!_crewaiEvaluator) {
-    _crewaiEvaluator = new Evaluator(findConfigPath("crewai"), "crewai");
+    const RuntimeAwareEvaluator = Evaluator as unknown as RuntimeAwareEvaluatorConstructor;
+    _crewaiEvaluator = new RuntimeAwareEvaluator(findConfigPath("crewai"), "crewai", {
+      enforcementMode: getCrewaiEnforcementMode(),
+      harness: "crewai",
+    });
   }
   return _crewaiEvaluator;
 }
@@ -34,7 +44,8 @@ function getCrewaiEnforcementMode(): "enforce" | "warn" {
     (config.enforcement_mode as string | undefined) ??
     (config.enforcementMode as string | undefined) ??
     process.env.APORT_ENFORCEMENT_MODE ??
-    process.env.APORT_ENFORCEMENT;
+    process.env.APORT_ENFORCEMENT ??
+    process.env.APORT_GUARDRAIL_ENFORCEMENT;
   const normalized = String(raw || "enforce").toLowerCase().replace(/_/g, "-");
   _crewaiEnforcementMode = ["warn", "report-only", "audit-only", "observe", "observation"].includes(normalized)
     ? "warn"
@@ -88,11 +99,12 @@ export function beforeToolCall(context: BeforeToolCallContext): false | null {
   if (!decision.allow) {
     const msg = sanitizeDisplayText(decision.reasons?.[0]?.message ?? "APort policy denied");
     const code = sanitizeDisplayText(decision.reasons?.[0]?.code ?? "oap.denied");
+    const toolName = sanitizeDisplayText(context.tool_name);
     if (getCrewaiEnforcementMode() === "warn") {
-      console.warn(`[APort] warning: policy would have denied ${context.tool_name}. Reason: ${code}.`);
+      console.warn(`[APort] warning: policy would have denied ${toolName}. Reason: ${code}.`);
       return null;
     }
-    console.warn(`[APort] denied ${context.tool_name}. Reason: ${code}. ${msg}`);
+    console.warn(`[APort] denied ${toolName}. Reason: ${code}. ${msg}`);
     return false;
   }
   return null;

--- a/packages/cursor/CHANGELOG.md
+++ b/packages/cursor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-cursor
 
+## 1.0.32
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.32
+
 ## 1.0.31
 
 ### Patch Changes

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-cursor",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "APort guardrails for Cursor IDE — VS Code extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/deprecated-agent-guardrails/package.json
+++ b/packages/deprecated-agent-guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/agent-guardrails",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "[DEPRECATED] Use @aporthq/aport-agent-guardrails instead. This package has been renamed for better SEO.",
   "deprecated": "This package has been renamed to @aporthq/aport-agent-guardrails. Please update your dependencies: npm install @aporthq/aport-agent-guardrails",
   "main": "index.js",

--- a/packages/langchain/CHANGELOG.md
+++ b/packages/langchain/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-langchain
 
+## 1.0.32
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.32
+
 ## 1.0.31
 
 ### Patch Changes

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-langchain",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "APort guardrails for LangChain/LangGraph — callback handler",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.31",
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.32",
     "@langchain/core": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/langchain/src/middleware.test.ts
+++ b/packages/langchain/src/middleware.test.ts
@@ -111,6 +111,10 @@ describe('APortGuardrailCallback', () => {
         'tool-call-1'
       )
     ).resolves.toBeUndefined();
+    expect(Evaluator).toHaveBeenCalledWith(null, 'langchain', {
+      enforcementMode: 'warn',
+      harness: 'langchain',
+    });
   });
 });
 

--- a/packages/langchain/src/middleware.test.ts
+++ b/packages/langchain/src/middleware.test.ts
@@ -116,6 +116,44 @@ describe('APortGuardrailCallback', () => {
       harness: 'langchain',
     });
   });
+
+  it('uses APORT_GUARDRAIL_ENFORCEMENT for warn mode when no direct override is set', async () => {
+    const originalEnforcementMode = process.env.APORT_ENFORCEMENT_MODE;
+    const originalEnforcement = process.env.APORT_ENFORCEMENT;
+    const originalGuardrailEnforcement = process.env.APORT_GUARDRAIL_ENFORCEMENT;
+    delete process.env.APORT_ENFORCEMENT_MODE;
+    delete process.env.APORT_ENFORCEMENT;
+    process.env.APORT_GUARDRAIL_ENFORCEMENT = 'warn';
+
+    (Evaluator as jest.Mock).mockImplementation(() => ({
+      verify: jest.fn().mockResolvedValue({
+        allow: false,
+        reasons: [{ code: 'oap.command_not_allowed', message: 'Tool not allowed by policy' }],
+      }),
+    }));
+
+    try {
+      const callback = new APortGuardrailCallback();
+      await expect(
+        callback.handleToolStart(
+          mockTool as any,
+          '{"command":"rm -rf /"}',
+          'run-1'
+        )
+      ).resolves.toBeUndefined();
+      expect(Evaluator).toHaveBeenCalledWith(null, 'langchain', {
+        enforcementMode: 'warn',
+        harness: 'langchain',
+      });
+    } finally {
+      if (originalEnforcementMode === undefined) delete process.env.APORT_ENFORCEMENT_MODE;
+      else process.env.APORT_ENFORCEMENT_MODE = originalEnforcementMode;
+      if (originalEnforcement === undefined) delete process.env.APORT_ENFORCEMENT;
+      else process.env.APORT_ENFORCEMENT = originalEnforcement;
+      if (originalGuardrailEnforcement === undefined) delete process.env.APORT_GUARDRAIL_ENFORCEMENT;
+      else process.env.APORT_GUARDRAIL_ENFORCEMENT = originalGuardrailEnforcement;
+    }
+  });
 });
 
 describe('GuardrailViolationError', () => {

--- a/packages/langchain/src/middleware.ts
+++ b/packages/langchain/src/middleware.ts
@@ -30,6 +30,12 @@ export interface APortGuardrailCallbackOptions {
   enforcementMode?: "enforce" | "warn";
 }
 
+type RuntimeAwareEvaluatorConstructor = new (
+  configPath?: string | null,
+  framework?: string,
+  runtimeOptions?: { enforcementMode?: string; harness?: string }
+) => Evaluator;
+
 /**
  * Callback handler that runs APort policy verification before each tool runs.
  * Register with LangChain/LangGraph so tool execution is blocked when policy denies.
@@ -48,12 +54,16 @@ export class APortGuardrailCallback extends BaseCallbackHandler {
       typeof options === "object" && options && "framework" in options
         ? options.framework ?? "langchain"
         : "langchain";
-    this.evaluator = new Evaluator(configPath, framework);
     this.enforcementMode = resolveEnforcementMode(
       typeof options === "object" && options ? options.enforcementMode : undefined,
       configPath,
       framework
     );
+    const RuntimeAwareEvaluator = Evaluator as unknown as RuntimeAwareEvaluatorConstructor;
+    this.evaluator = new RuntimeAwareEvaluator(configPath, framework, {
+      enforcementMode: this.enforcementMode,
+      harness: framework,
+    });
   }
 
   async handleToolStart(

--- a/packages/langchain/src/middleware.ts
+++ b/packages/langchain/src/middleware.ts
@@ -99,11 +99,12 @@ export class APortGuardrailCallback extends BaseCallbackHandler {
       const code = decision.reasons?.[0]?.code ?? "oap.denied";
       const safeMessage = sanitizeDisplayText(msg);
       const safeCode = sanitizeDisplayText(code);
+      const safeToolName = sanitizeDisplayText(toolName);
       if (this.enforcementMode === "warn") {
-        console.warn(`[APort] warning: policy would have denied ${toolName}. Reason: ${safeCode}.`);
+        console.warn(`[APort] warning: policy would have denied ${safeToolName}. Reason: ${safeCode}.`);
         return;
       }
-      console.warn(`[APort] denied ${toolName}. Reason: ${safeCode}. ${safeMessage}`);
+      console.warn(`[APort] denied ${safeToolName}. Reason: ${safeCode}. ${safeMessage}`);
       throw new GuardrailViolationError(msg, decision.reasons);
     }
   }
@@ -121,7 +122,8 @@ function resolveEnforcementMode(
     (config.enforcement_mode as string | undefined) ??
     (config.enforcementMode as string | undefined) ??
     process.env.APORT_ENFORCEMENT_MODE ??
-    process.env.APORT_ENFORCEMENT;
+    process.env.APORT_ENFORCEMENT ??
+    process.env.APORT_GUARDRAIL_ENFORCEMENT;
   const normalized = String(raw || "enforce").toLowerCase().replace(/_/g, "-");
   return ["warn", "report-only", "audit-only", "observe", "observation"].includes(normalized)
     ? "warn"

--- a/packages/n8n/CHANGELOG.md
+++ b/packages/n8n/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aporthq/aport-agent-guardrails-n8n
 
+## 1.0.32
+
+### Patch Changes
+
+- Updated dependencies
+  - @aporthq/aport-agent-guardrails-core@1.0.32
+
 ## 1.0.31
 
 ### Patch Changes

--- a/packages/n8n/package.json
+++ b/packages/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aporthq/aport-agent-guardrails-n8n",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "APort guardrails for n8n — custom node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "APort Technologies Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aporthq/aport-agent-guardrails-core": ">=1.0.31"
+    "@aporthq/aport-agent-guardrails-core": ">=1.0.32"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/python/aport_guardrails/__init__.py
+++ b/python/aport_guardrails/__init__.py
@@ -3,7 +3,7 @@ aport_guardrails — Core evaluator, passport, and config for APort agent guardr
 Shared across Python framework adapters (LangChain, CrewAI, AutoGen).
 """
 
-__version__ = "1.0.31"
+__version__ = "1.0.32"
 
 from aport_guardrails.core.evaluator import Evaluator, Decision, ToolContext
 from aport_guardrails.core.passport import load_passport, validate_passport

--- a/python/aport_guardrails/core/display.py
+++ b/python/aport_guardrails/core/display.py
@@ -43,17 +43,22 @@ def policy_reference(*, framework: str | None = None, config_path: str | None = 
     if resolved_path:
         config = load_config(resolved_path)
 
-    agent_id = (
-        os.environ.get("APORT_AGENT_ID")
-        or str(config.get("agent_id") or config.get("agentId") or config.get("hosted_agent_id") or "")
+    agent_id = str(
+        config.get("agent_id")
+        or config.get("agentId")
+        or config.get("hosted_agent_id")
+        or os.environ.get("APORT_AGENT_ID")
+        or ""
     )
     if agent_id:
         return f"Review or update the hosted passport: {app_url}/passports?details={agent_id}"
 
-    passport_path = (
-        os.environ.get("APORT_PASSPORT_FILE")
+    passport_path = str(
+        config.get("passport_path")
+        or config.get("passportFile")
+        or os.environ.get("APORT_PASSPORT_FILE")
         or os.environ.get("PASSPORT_FILE")
-        or str(config.get("passport_path") or config.get("passportFile") or "")
+        or ""
     )
     if passport_path:
         return f"Review or update the local passport file: {passport_path}"

--- a/python/aport_guardrails/core/display.py
+++ b/python/aport_guardrails/core/display.py
@@ -1,0 +1,88 @@
+"""Display helpers for safe, actionable guardrail messages."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from aport_guardrails.core.config import find_config_path, load_config
+
+
+def sanitize_display(value: Any, limit: int = 320) -> str:
+    """Strip control characters and redact common secrets before terminal output."""
+    text = str(value or "").replace("\n", " ").replace("\r", " ").replace("\t", " ").replace("::", ": :")
+    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
+    replacements = (
+        (r"(?:apk|aprt)_[A-Za-z0-9_-]+", "[REDACTED_APORT_KEY]"),
+        (r"github_pat_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]"),
+        (r"gh[pousr]_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]"),
+        (r"xox[baprs]-[A-Za-z0-9-]+", "[REDACTED_SLACK_TOKEN]"),
+        (r"AKIA[0-9A-Z]{16}", "[REDACTED_AWS_KEY]"),
+        (r"(Authorization:?\s*Bearer|Bearer)\s+[A-Za-z0-9._~+/-]+=*", r"\1 [REDACTED]"),
+        (r"(password|passwd|pwd|token|secret|api[_-]?key)=\S+", r"\1=[REDACTED]"),
+        (r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", "[REDACTED_PRIVATE_KEY]"),
+    )
+    for pattern, replacement in replacements:
+        text = re.sub(pattern, replacement, text, flags=re.IGNORECASE | re.DOTALL)
+    return text[:limit]
+
+
+def policy_reference(*, framework: str | None = None, config_path: str | None = None) -> str:
+    """Return the safest user-facing place to review the active passport/config."""
+    app_url = os.environ.get("APORT_APP_URL", "https://aport.io").rstrip("/")
+    config: dict[str, Any] = {}
+    resolved_path: Path | None = None
+
+    if config_path:
+        resolved_path = Path(config_path).expanduser()
+    elif framework:
+        resolved_path = find_config_path(framework)
+
+    if resolved_path:
+        config = load_config(resolved_path)
+
+    agent_id = (
+        os.environ.get("APORT_AGENT_ID")
+        or str(config.get("agent_id") or config.get("agentId") or config.get("hosted_agent_id") or "")
+    )
+    if agent_id:
+        return f"Review or update the hosted passport: {app_url}/passports?details={agent_id}"
+
+    passport_path = (
+        os.environ.get("APORT_PASSPORT_FILE")
+        or os.environ.get("PASSPORT_FILE")
+        or str(config.get("passport_path") or config.get("passportFile") or "")
+    )
+    if passport_path:
+        return f"Review or update the local passport file: {passport_path}"
+
+    return f"Review the APort setup for this framework: {app_url}/quickstart"
+
+
+def format_policy_warning(
+    *,
+    policy: str,
+    reason_code: Any = "oap.denied",
+    reason_message: Any = "",
+    tool_name: Any = "",
+    framework: str | None = None,
+    config_path: str | None = None,
+) -> str:
+    """Build a consistent report-only warning for framework adapters."""
+    safe_policy = sanitize_display(policy)
+    safe_reason_code = sanitize_display(reason_code or "oap.denied")
+    safe_reason_message = sanitize_display(reason_message or "")
+    safe_tool_name = sanitize_display(tool_name)
+    safe_reference = sanitize_display(policy_reference(framework=framework, config_path=config_path))
+
+    parts = ["[APort] warning: policy would have denied this tool call."]
+    if safe_tool_name:
+        parts.append(f"Tool: {safe_tool_name}.")
+    parts.append(f"Policy: {safe_policy}.")
+    parts.append(f"Reason: {safe_reason_code}.")
+    if safe_reason_message and safe_reason_message != safe_reason_code:
+        parts.append(f"Detail: {safe_reason_message}.")
+    parts.append(f"Review: {safe_reference}.")
+    return " ".join(parts)

--- a/python/aport_guardrails/core/evaluator.py
+++ b/python/aport_guardrails/core/evaluator.py
@@ -402,17 +402,24 @@ def _normalize_runtime_enforcement(value: Any) -> str:
     return "enforce"
 
 
-def _runtime_metadata(config: dict[str, Any], fallback_harness: str) -> dict[str, str]:
+def _runtime_metadata(
+    config: dict[str, Any],
+    fallback_harness: str,
+    *,
+    enforcement_mode: Any = None,
+    harness: Any = None,
+) -> dict[str, str]:
     return {
         "enforcement_mode": _normalize_runtime_enforcement(
-            config.get("enforcement_mode")
+            enforcement_mode
+            or config.get("enforcement_mode")
             or config.get("enforcementMode")
             or os.environ.get("APORT_ENFORCEMENT_MODE")
             or os.environ.get("APORT_ENFORCEMENT")
             or os.environ.get("APORT_GUARDRAIL_ENFORCEMENT")
         ),
         "enforced_by": "aport-agent-guardrails-python",
-        "harness": _normalize_runtime_string(config.get("framework"), fallback_harness),
+        "harness": _normalize_runtime_string(harness or config.get("framework"), fallback_harness),
     }
 
 
@@ -493,9 +500,13 @@ class Evaluator:
         config_path: str | Path | None = None,
         *,
         framework: str = "langchain",
+        enforcement_mode: Any = None,
+        harness: Any = None,
     ) -> None:
         self.config_path = Path(config_path) if config_path else None
         self._framework = framework
+        self._runtime_enforcement_mode = enforcement_mode
+        self._runtime_harness = harness
         self._config: dict[str, Any] | None = None
 
     def _load_config(self) -> dict[str, Any]:
@@ -582,7 +593,12 @@ class Evaluator:
             api_url = config.get("api_url") or os.environ.get("APORT_API_URL", "https://api.aport.io")
             api_key = config.get("api_key") or os.environ.get("APORT_API_KEY")
             agent_id = config.get("agent_id") or passport.get("agent_id")
-            runtime = _runtime_metadata(config, self._framework)
+            runtime = _runtime_metadata(
+                config,
+                self._framework,
+                enforcement_mode=self._runtime_enforcement_mode,
+                harness=self._runtime_harness,
+            )
             # SECURITY: Check if SSL verification should be disabled (dev/test only)
             verify_ssl = config.get("verify_ssl", True)
             if os.environ.get("APORT_VERIFY_SSL") == "0":
@@ -681,7 +697,12 @@ class Evaluator:
             api_url = config.get("api_url") or os.environ.get("APORT_API_URL", "https://api.aport.io")
             api_key = config.get("api_key") or os.environ.get("APORT_API_KEY")
             agent_id = config.get("agent_id") or passport.get("agent_id")
-            runtime = _runtime_metadata(config, self._framework)
+            runtime = _runtime_metadata(
+                config,
+                self._framework,
+                enforcement_mode=self._runtime_enforcement_mode,
+                harness=self._runtime_harness,
+            )
             # SECURITY: Check if SSL verification should be disabled (dev/test only)
             verify_ssl = config.get("verify_ssl", True)
             if os.environ.get("APORT_VERIFY_SSL") == "0":

--- a/python/aport_guardrails/core/evaluator.py
+++ b/python/aport_guardrails/core/evaluator.py
@@ -388,6 +388,34 @@ def _is_full_policy_pack(p: Any) -> bool:
     return bool(p.get("id") and p.get("requires_capabilities") is not None)
 
 
+def _normalize_runtime_string(value: Any, fallback: str) -> str:
+    normalized = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    normalized = "".join(" " if ord(ch) < 32 or ord(ch) == 127 else ch for ch in normalized)
+    normalized = " ".join(normalized.split())
+    return (normalized or fallback)[:80]
+
+
+def _normalize_runtime_enforcement(value: Any) -> str:
+    raw = str(value or "enforce").strip().lower().replace("_", "-")
+    if raw in {"warn", "report-only", "audit-only", "observe", "observation"}:
+        return "warn"
+    return "enforce"
+
+
+def _runtime_metadata(config: dict[str, Any], fallback_harness: str) -> dict[str, str]:
+    return {
+        "enforcement_mode": _normalize_runtime_enforcement(
+            config.get("enforcement_mode")
+            or config.get("enforcementMode")
+            or os.environ.get("APORT_ENFORCEMENT_MODE")
+            or os.environ.get("APORT_ENFORCEMENT")
+            or os.environ.get("APORT_GUARDRAIL_ENFORCEMENT")
+        ),
+        "enforced_by": "aport-agent-guardrails-python",
+        "harness": _normalize_runtime_string(config.get("framework"), fallback_harness),
+    }
+
+
 def _call_api_sync(
     api_url: str,
     pack_id: str,
@@ -398,6 +426,7 @@ def _call_api_sync(
     policy_pack: dict[str, Any] | None = None,
     api_key: str | None = None,
     verify_ssl: bool = True,
+    runtime: dict[str, str] | None = None,
 ) -> Decision:
     """
     Call APort API: POST /api/verify/policy/{pack_id}.
@@ -428,6 +457,8 @@ def _call_api_sync(
         body["passport"] = passport
     if policy_pack and _is_full_policy_pack(policy_pack):
         body["policy"] = policy_pack
+    if runtime:
+        body["runtime"] = runtime
     try:
         req = Request(url, data=json.dumps(body).encode(), method="POST")
         req.add_header("Content-Type", "application/json")
@@ -551,6 +582,7 @@ class Evaluator:
             api_url = config.get("api_url") or os.environ.get("APORT_API_URL", "https://api.aport.io")
             api_key = config.get("api_key") or os.environ.get("APORT_API_KEY")
             agent_id = config.get("agent_id") or passport.get("agent_id")
+            runtime = _runtime_metadata(config, self._framework)
             # SECURITY: Check if SSL verification should be disabled (dev/test only)
             verify_ssl = config.get("verify_ssl", True)
             if os.environ.get("APORT_VERIFY_SSL") == "0":
@@ -574,6 +606,7 @@ class Evaluator:
                     policy_pack=policy_pack,
                     api_key=api_key,
                     verify_ssl=verify_ssl,
+                    runtime=runtime,
                 )
                 self._audit_log(config, tool_name, pack_id, decision, ctx)
                 return decision
@@ -587,6 +620,7 @@ class Evaluator:
                     policy_pack=policy_pack,
                     api_key=api_key,
                     verify_ssl=verify_ssl,
+                    runtime=runtime,
                 )
                 self._audit_log(config, tool_name, pack_id, decision, ctx)
                 return decision
@@ -647,6 +681,7 @@ class Evaluator:
             api_url = config.get("api_url") or os.environ.get("APORT_API_URL", "https://api.aport.io")
             api_key = config.get("api_key") or os.environ.get("APORT_API_KEY")
             agent_id = config.get("agent_id") or passport.get("agent_id")
+            runtime = _runtime_metadata(config, self._framework)
             # SECURITY: Check if SSL verification should be disabled (dev/test only)
             verify_ssl = config.get("verify_ssl", True)
             if os.environ.get("APORT_VERIFY_SSL") == "0":
@@ -662,13 +697,13 @@ class Evaluator:
                     passport_body = None
             if agent_id:
                 decision = _call_api_sync(
-                    api_url, pack_id, ctx, agent_id=agent_id, policy_pack=policy_pack, api_key=api_key, verify_ssl=verify_ssl
+                    api_url, pack_id, ctx, agent_id=agent_id, policy_pack=policy_pack, api_key=api_key, verify_ssl=verify_ssl, runtime=runtime
                 )
                 self._audit_log(config, tool_name, pack_id, decision, ctx)
                 return decision
             if passport_body:
                 decision = _call_api_sync(
-                    api_url, pack_id, ctx, passport=passport_body, policy_pack=policy_pack, api_key=api_key, verify_ssl=verify_ssl
+                    api_url, pack_id, ctx, passport=passport_body, policy_pack=policy_pack, api_key=api_key, verify_ssl=verify_ssl, runtime=runtime
                 )
                 self._audit_log(config, tool_name, pack_id, decision, ctx)
                 return decision

--- a/python/aport_guardrails/providers/generic.py
+++ b/python/aport_guardrails/providers/generic.py
@@ -48,6 +48,8 @@ class OAPGuardrailProvider:
         self._evaluator = Evaluator(
             resolved_config_path,
             framework=framework,
+            enforcement_mode=self._enforcement_mode,
+            harness=framework,
         )
 
     def _build_context(self, request: Any) -> dict:

--- a/python/aport_guardrails/pyproject.toml
+++ b/python/aport_guardrails/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails"
-version = "1.0.31"
+version = "1.0.32"
 description = "APort Agent Guardrail — shared core for AI agent and LLM frameworks (pre-action authorization)"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/aport_guardrails/tests/test_display.py
+++ b/python/aport_guardrails/tests/test_display.py
@@ -1,0 +1,48 @@
+"""Tests for safe, actionable display helpers."""
+
+from aport_guardrails.core.display import format_policy_warning, policy_reference, sanitize_display
+
+
+def test_sanitize_display_redacts_tokens_and_control_text():
+    output = sanitize_display("tool\n::error::fake apk_secret github_pat_secret")
+
+    assert "\n::error::" not in output
+    assert "apk_secret" not in output
+    assert "github_pat_secret" not in output
+    assert "[REDACTED_APORT_KEY]" in output
+    assert "[REDACTED_GITHUB_TOKEN]" in output
+
+
+def test_policy_reference_prefers_hosted_agent_id(monkeypatch):
+    monkeypatch.setenv("APORT_AGENT_ID", "ap_1234567890abcdef1234567890abcdef")
+
+    assert (
+        policy_reference(framework="langchain")
+        == "Review or update the hosted passport: https://aport.io/passports?details=ap_1234567890abcdef1234567890abcdef"
+    )
+
+
+def test_policy_reference_uses_local_passport_file(monkeypatch):
+    monkeypatch.delenv("APORT_AGENT_ID", raising=False)
+    monkeypatch.setenv("APORT_PASSPORT_FILE", "/tmp/aport/passport.json")
+
+    assert policy_reference(framework="crewai") == "Review or update the local passport file: /tmp/aport/passport.json"
+
+
+def test_format_policy_warning_includes_actionable_review(monkeypatch):
+    monkeypatch.setenv("APORT_AGENT_ID", "ap_abcdefabcdefabcdefabcdefabcdef12")
+
+    output = format_policy_warning(
+        policy="system.command.execute.v1",
+        reason_code="oap.command_not_allowed",
+        reason_message="Command not in allowlist",
+        tool_name="run_command",
+        framework="langchain",
+    )
+
+    assert "policy would have denied this tool call" in output
+    assert "Tool: run_command." in output
+    assert "Policy: system.command.execute.v1." in output
+    assert "Reason: oap.command_not_allowed." in output
+    assert "Detail: Command not in allowlist." in output
+    assert "Review: Review or update the hosted passport:" in output

--- a/python/aport_guardrails/tests/test_display.py
+++ b/python/aport_guardrails/tests/test_display.py
@@ -1,5 +1,6 @@
 """Tests for safe, actionable display helpers."""
 
+import aport_guardrails.core.display as display
 from aport_guardrails.core.display import format_policy_warning, policy_reference, sanitize_display
 
 
@@ -19,6 +20,18 @@ def test_policy_reference_prefers_hosted_agent_id(monkeypatch):
     assert (
         policy_reference(framework="langchain")
         == "Review or update the hosted passport: https://aport.io/passports?details=ap_1234567890abcdef1234567890abcdef"
+    )
+
+
+def test_policy_reference_prefers_config_agent_id_over_stale_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("APORT_AGENT_ID", "ap_stale_global")
+    monkeypatch.setattr(display, "load_config", lambda _path: {"agent_id": "ap_configured_agent"})
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agent_id: ap_configured_agent\n")
+
+    assert (
+        policy_reference(config_path=str(config_path))
+        == "Review or update the hosted passport: https://aport.io/passports?details=ap_configured_agent"
     )
 
 

--- a/python/aport_guardrails/tests/test_evaluator.py
+++ b/python/aport_guardrails/tests/test_evaluator.py
@@ -65,6 +65,34 @@ class TestCallApiSyncPolicyInBody:
         assert body["context"].get("agent_id") == "agent-1"
 
     @patch("aport_guardrails.core.evaluator.urlopen")
+    def test_runtime_metadata_is_sent_to_api(self, urlopen_mock):
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({"allow": True, "reasons": []}).encode()
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        urlopen_mock.return_value = resp
+
+        _call_api_sync(
+            "https://api.example.com",
+            "system.command.execute.v1",
+            {"tool": "exec.run"},
+            agent_id="agent-1",
+            runtime={
+                "enforcement_mode": "warn",
+                "enforced_by": "aport-agent-guardrails-python",
+                "harness": "langchain",
+            },
+        )
+
+        call_args = urlopen_mock.call_args[0][0]
+        body = json.loads(call_args.data.decode())
+        assert body["runtime"] == {
+            "enforcement_mode": "warn",
+            "enforced_by": "aport-agent-guardrails-python",
+            "harness": "langchain",
+        }
+
+    @patch("aport_guardrails.core.evaluator.urlopen")
     def test_preserves_full_decision_metadata(self, urlopen_mock):
         resp = MagicMock()
         resp.read.return_value = json.dumps({

--- a/python/aport_guardrails/tests/test_evaluator.py
+++ b/python/aport_guardrails/tests/test_evaluator.py
@@ -161,6 +161,36 @@ class TestEvaluatorVerifyPolicyInBody:
         assert kwargs.get("policy_pack") == full_policy
         assert kwargs.get("agent_id") == "agent-1"
 
+    @pytest.mark.asyncio
+    @patch("aport_guardrails.core.evaluator._call_api_sync")
+    async def test_verify_reports_runtime_override_to_api(self, call_api_mock):
+        call_api_mock.return_value = {"allow": False, "reasons": [{"code": "oap.denied"}]}
+
+        evaluator = Evaluator(
+            framework="langchain",
+            enforcement_mode="warn",
+            harness="langchain",
+        )
+        evaluator._config = {
+            "mode": "api",
+            "api_url": "https://api.example.com",
+            "agent_id": "agent-1",
+            "enforcement_mode": "enforce",
+        }
+
+        await evaluator.verify(
+            passport={"agent_id": "agent-1"},
+            policy={"capability": "system.command.execute.v1"},
+            context={"tool": "run"},
+        )
+
+        call_api_mock.assert_called_once()
+        assert call_api_mock.call_args.kwargs["runtime"] == {
+            "enforcement_mode": "warn",
+            "enforced_by": "aport-agent-guardrails-python",
+            "harness": "langchain",
+        }
+
 
 class TestGuardrailScriptResolution:
     def test_prefers_framework_runtime_installed_under_config_dir(self, tmp_path: Path):

--- a/python/aport_guardrails/tests/test_generic_provider.py
+++ b/python/aport_guardrails/tests/test_generic_provider.py
@@ -60,6 +60,18 @@ class TestToResult:
 class TestOAPGuardrailProvider:
     @patch("aport_guardrails.providers.generic.find_config_path", return_value=None)
     @patch("aport_guardrails.providers.generic.Evaluator")
+    def test_constructor_passes_enforcement_override_to_evaluator(self, mock_evaluator_cls, mock_find):
+        OAPGuardrailProvider(framework="deerflow", enforcement_mode="warn")
+
+        mock_evaluator_cls.assert_called_once_with(
+            None,
+            framework="deerflow",
+            enforcement_mode="warn",
+            harness="deerflow",
+        )
+
+    @patch("aport_guardrails.providers.generic.find_config_path", return_value=None)
+    @patch("aport_guardrails.providers.generic.Evaluator")
     def test_evaluate_calls_verify_sync(self, mock_evaluator_cls, mock_find):
         mock_evaluator = MagicMock()
         mock_evaluator.verify_sync.return_value = {"allow": True, "reasons": [{"code": "oap.allowed", "message": ""}]}

--- a/python/crewai_adapter/aport_guardrails_crewai/hook.py
+++ b/python/crewai_adapter/aport_guardrails_crewai/hook.py
@@ -14,7 +14,12 @@ _crewai_enforcement_mode: str | None = None
 def _get_crewai_evaluator() -> Evaluator:
     global _crewai_evaluator
     if _crewai_evaluator is None:
-        _crewai_evaluator = Evaluator(config_path=find_config_path("crewai"), framework="crewai")
+        _crewai_evaluator = Evaluator(
+            config_path=find_config_path("crewai"),
+            framework="crewai",
+            enforcement_mode=_get_enforcement_mode(),
+            harness="crewai",
+        )
     return _crewai_evaluator
 
 
@@ -34,6 +39,7 @@ def _get_enforcement_mode() -> str:
         or config.get("enforcementMode")
         or os.environ.get("APORT_ENFORCEMENT_MODE")
         or os.environ.get("APORT_ENFORCEMENT")
+        or os.environ.get("APORT_GUARDRAIL_ENFORCEMENT")
     )
     return _crewai_enforcement_mode
 

--- a/python/crewai_adapter/aport_guardrails_crewai/hook.py
+++ b/python/crewai_adapter/aport_guardrails_crewai/hook.py
@@ -1,11 +1,11 @@
 """CrewAI before_tool_call hook: verify tool execution with APort."""
 
 import os
-import re
 from typing import Any
 
 from aport_guardrails.core import Evaluator, build_tool_context, tool_to_pack_id
 from aport_guardrails.core.config import find_config_path, load_config
+from aport_guardrails.core.display import format_policy_warning
 
 _crewai_evaluator: Evaluator | None = None
 _crewai_enforcement_mode: str | None = None
@@ -38,20 +38,6 @@ def _get_enforcement_mode() -> str:
     return _crewai_enforcement_mode
 
 
-def _sanitize_display(value: Any) -> str:
-    text = str(value or "")
-    text = re.sub(r"[\r\n\t]+", " ", text)
-    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
-    text = re.sub(r"(?:apk|aprt)_[A-Za-z0-9_-]+", "[REDACTED_APORT_KEY]", text)
-    text = re.sub(r"github_pat_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]", text)
-    text = re.sub(r"gh[pousr]_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]", text)
-    text = re.sub(r"xox[baprs]-[A-Za-z0-9-]+", "[REDACTED_SLACK_TOKEN]", text)
-    text = re.sub(r"AKIA[0-9A-Z]{16}", "[REDACTED_AWS_KEY]", text)
-    text = re.sub(r"(Authorization:?\s*Bearer|Bearer)\s+[A-Za-z0-9._~+/-]+=*", r"\1 [REDACTED]", text, flags=re.IGNORECASE)
-    text = re.sub(r"(password|passwd|pwd|token|secret|api[_-]?key)=\S+", r"\1=[REDACTED]", text, flags=re.IGNORECASE)
-    return text[:240]
-
-
 def aport_guardrail_before_tool_call(context: Any) -> bool | None:
     """
     CrewAI before_tool_call hook: run APort verification; return False to block, None to allow.
@@ -69,9 +55,16 @@ def aport_guardrail_before_tool_call(context: Any) -> bool | None:
     if not decision.get("allow", False):
         if _get_enforcement_mode() == "warn":
             reasons = decision.get("reasons") or [{}]
-            code = _sanitize_display(reasons[0].get("code", "oap.denied") if reasons else "oap.denied")
-            tool_name = _sanitize_display(context.tool_name)
-            print(f"[APort] warning: policy would have denied {tool_name}. Reason: {code}.")
+            reason = reasons[0] if reasons else {}
+            print(
+                format_policy_warning(
+                    policy=pack_id,
+                    reason_code=reason.get("code", "oap.denied"),
+                    reason_message=reason.get("message", ""),
+                    tool_name=context.tool_name,
+                    framework="crewai",
+                )
+            )
             return None
         return False
     return None

--- a/python/crewai_adapter/hook.py
+++ b/python/crewai_adapter/hook.py
@@ -14,7 +14,12 @@ _crewai_enforcement_mode: str | None = None
 def _get_crewai_evaluator() -> Evaluator:
     global _crewai_evaluator
     if _crewai_evaluator is None:
-        _crewai_evaluator = Evaluator(config_path=find_config_path("crewai"), framework="crewai")
+        _crewai_evaluator = Evaluator(
+            config_path=find_config_path("crewai"),
+            framework="crewai",
+            enforcement_mode=_get_enforcement_mode(),
+            harness="crewai",
+        )
     return _crewai_evaluator
 
 
@@ -34,6 +39,7 @@ def _get_enforcement_mode() -> str:
         or config.get("enforcementMode")
         or os.environ.get("APORT_ENFORCEMENT_MODE")
         or os.environ.get("APORT_ENFORCEMENT")
+        or os.environ.get("APORT_GUARDRAIL_ENFORCEMENT")
     )
     return _crewai_enforcement_mode
 

--- a/python/crewai_adapter/hook.py
+++ b/python/crewai_adapter/hook.py
@@ -1,11 +1,11 @@
 """CrewAI before_tool_call hook: verify tool execution with APort."""
 
 import os
-import re
 from typing import Any
 
 from aport_guardrails.core import Evaluator, build_tool_context, tool_to_pack_id
 from aport_guardrails.core.config import find_config_path, load_config
+from aport_guardrails.core.display import format_policy_warning
 
 _crewai_evaluator: Evaluator | None = None
 _crewai_enforcement_mode: str | None = None
@@ -38,20 +38,6 @@ def _get_enforcement_mode() -> str:
     return _crewai_enforcement_mode
 
 
-def _sanitize_display(value: Any) -> str:
-    text = str(value or "")
-    text = re.sub(r"[\r\n\t]+", " ", text)
-    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
-    text = re.sub(r"(?:apk|aprt)_[A-Za-z0-9_-]+", "[REDACTED_APORT_KEY]", text)
-    text = re.sub(r"github_pat_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]", text)
-    text = re.sub(r"gh[pousr]_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]", text)
-    text = re.sub(r"xox[baprs]-[A-Za-z0-9-]+", "[REDACTED_SLACK_TOKEN]", text)
-    text = re.sub(r"AKIA[0-9A-Z]{16}", "[REDACTED_AWS_KEY]", text)
-    text = re.sub(r"(Authorization:?\s*Bearer|Bearer)\s+[A-Za-z0-9._~+/-]+=*", r"\1 [REDACTED]", text, flags=re.IGNORECASE)
-    text = re.sub(r"(password|passwd|pwd|token|secret|api[_-]?key)=\S+", r"\1=[REDACTED]", text, flags=re.IGNORECASE)
-    return text[:240]
-
-
 def aport_guardrail_before_tool_call(context: Any) -> bool | None:
     """
     CrewAI before_tool_call hook: run APort verification; return False to block, None to allow.
@@ -69,9 +55,16 @@ def aport_guardrail_before_tool_call(context: Any) -> bool | None:
     if not decision.get("allow", False):
         if _get_enforcement_mode() == "warn":
             reasons = decision.get("reasons") or [{}]
-            code = _sanitize_display(reasons[0].get("code", "oap.denied") if reasons else "oap.denied")
-            tool_name = _sanitize_display(context.tool_name)
-            print(f"[APort] warning: policy would have denied {tool_name}. Reason: {code}.")
+            reason = reasons[0] if reasons else {}
+            print(
+                format_policy_warning(
+                    policy=pack_id,
+                    reason_code=reason.get("code", "oap.denied"),
+                    reason_message=reason.get("message", ""),
+                    tool_name=context.tool_name,
+                    framework="crewai",
+                )
+            )
             return None
         return False
     return None

--- a/python/crewai_adapter/pyproject.toml
+++ b/python/crewai_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-crewai"
-version = "1.0.31"
+version = "1.0.32"
 description = "APort Agent Guardrail for CrewAI — before_tool_call hook for AI agent and multi-agent crews"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -12,7 +12,7 @@ authors = [{ name = "APort Technologies Inc." }]
 keywords = ["aport", "agent guardrail", "LLM guardrail", "crewai", "guardrails", "multi-agent", "AI agent"]
 requires-python = ">=3.10"
 dependencies = [
-    "aport-agent-guardrails>=1.0.31,<2",
+    "aport-agent-guardrails>=1.0.32,<2",
     "crewai>=0.80",
 ]
 

--- a/python/crewai_adapter/tests/test_hook.py
+++ b/python/crewai_adapter/tests/test_hook.py
@@ -63,6 +63,29 @@ class TestAportGuardrailBeforeToolCall:
         assert result is None
 
     @patch("crewai_adapter.hook.Evaluator")
+    def test_guardrail_enforcement_env_sets_warn_runtime_metadata(
+        self,
+        mock_evaluator_cls: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """APORT_GUARDRAIL_ENFORCEMENT should drive both CrewAI behavior and hosted metadata."""
+        hook._crewai_evaluator = None
+        hook._crewai_enforcement_mode = None
+        monkeypatch.delenv("APORT_ENFORCEMENT", raising=False)
+        monkeypatch.delenv("APORT_ENFORCEMENT_MODE", raising=False)
+        monkeypatch.setenv("APORT_GUARDRAIL_ENFORCEMENT", "warn")
+        mock_evaluator_cls.return_value.verify_sync.return_value = {
+            "allow": False,
+            "reasons": [{"code": "oap.command_not_allowed", "message": "Command not in allowlist"}],
+        }
+
+        result = aport_guardrail_before_tool_call(_fake_context(tool_input={"command": "rm -rf /"}))
+
+        assert result is None
+        assert mock_evaluator_cls.call_args.kwargs["enforcement_mode"] == "warn"
+        assert mock_evaluator_cls.call_args.kwargs["harness"] == "crewai"
+
+    @patch("crewai_adapter.hook.Evaluator")
     def test_warn_mode_sanitizes_display_output(
         self,
         mock_evaluator_cls: MagicMock,

--- a/python/crewai_adapter/tests/test_hook.py
+++ b/python/crewai_adapter/tests/test_hook.py
@@ -87,6 +87,7 @@ class TestAportGuardrailBeforeToolCall:
         assert "\n::stop-commands::" not in output
         assert "apk_testsecret" not in output
         assert "[REDACTED_APORT_KEY]" in output
+        assert "Review:" in output
 
     @patch("crewai_adapter.hook.Evaluator")
     def test_context_input_serialized(self, mock_evaluator_cls: MagicMock) -> None:

--- a/python/langchain_adapter/aport_guardrails_langchain/middleware.py
+++ b/python/langchain_adapter/aport_guardrails_langchain/middleware.py
@@ -32,6 +32,7 @@ def _resolve_enforcement_mode(config_path: str | None, framework: str, explicit:
         or config.get("enforcementMode")
         or os.environ.get("APORT_ENFORCEMENT_MODE")
         or os.environ.get("APORT_ENFORCEMENT")
+        or os.environ.get("APORT_GUARDRAIL_ENFORCEMENT")
     )
 
 

--- a/python/langchain_adapter/aport_guardrails_langchain/middleware.py
+++ b/python/langchain_adapter/aport_guardrails_langchain/middleware.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +13,7 @@ except Exception:  # pragma: no cover - keeps the package usable without LangCha
 
 from aport_guardrails.core.config import find_config_path, load_config
 from aport_guardrails.core import Evaluator, GuardrailViolation, build_tool_context, tool_to_pack_id
+from aport_guardrails.core.display import format_policy_warning
 
 
 def _normalize_enforcement_mode(value: Any) -> str:
@@ -59,30 +59,13 @@ def _tool_input(input_str: Any, inputs: Any) -> str | dict[str, Any]:
     return str(value)
 
 
-def _sanitize_display(value: Any) -> str:
-    text = str(value or "").replace("\n", " ").replace("\r", " ").replace("\t", " ").replace("::", ": :")
-    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
-    replacements = (
-        (r"(?:apk|aprt)_[A-Za-z0-9_-]+", "[REDACTED_APORT_KEY]"),
-        (r"github_pat_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]"),
-        (r"gh[pousr]_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]"),
-        (r"xox[baprs]-[A-Za-z0-9-]+", "[REDACTED_SLACK_TOKEN]"),
-        (r"AKIA[0-9A-Z]{16}", "[REDACTED_AWS_KEY]"),
-        (r"(Authorization:?\s*Bearer|Bearer)\s+[A-Za-z0-9._~+/-]+=*", r"\1 [REDACTED]"),
-        (r"(password|passwd|pwd|token|secret|api[_-]?key)=\S+", r"\1=[REDACTED]"),
-        (r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", "[REDACTED_PRIVATE_KEY]"),
-    )
-    for pattern, replacement in replacements:
-        text = re.sub(pattern, replacement, text, flags=re.IGNORECASE | re.DOTALL)
-    return text[:240]
-
-
 class APortCallback(AsyncCallbackHandler):
     """Callback that verifies tool execution with APort before allowing. Auto-loads config from .aport/config.yaml or ~/.aport/langchain/."""
 
     raise_error = True
 
     def __init__(self, config_path: str | None = None, enforcement_mode: str | None = None) -> None:
+        self.config_path = config_path
         self.evaluator = Evaluator(config_path, framework="langchain")
         self.enforcement_mode = _resolve_enforcement_mode(config_path, "langchain", enforcement_mode)
 
@@ -102,8 +85,14 @@ class APortCallback(AsyncCallbackHandler):
             code = reasons[0].get("code", "oap.denied") if reasons else "oap.denied"
             if self.enforcement_mode == "warn":
                 print(
-                    f"[APort] warning: policy would have denied "
-                    f"{_sanitize_display(tool_name)}. Reason: {_sanitize_display(code)}."
+                    format_policy_warning(
+                        policy=pack_id,
+                        reason_code=code,
+                        reason_message=msg,
+                        tool_name=tool_name,
+                        framework="langchain",
+                        config_path=self.config_path,
+                    )
                 )
                 return
             raise GuardrailViolation(msg, code=code, reasons=reasons)

--- a/python/langchain_adapter/aport_guardrails_langchain/middleware.py
+++ b/python/langchain_adapter/aport_guardrails_langchain/middleware.py
@@ -66,8 +66,13 @@ class APortCallback(AsyncCallbackHandler):
 
     def __init__(self, config_path: str | None = None, enforcement_mode: str | None = None) -> None:
         self.config_path = config_path
-        self.evaluator = Evaluator(config_path, framework="langchain")
         self.enforcement_mode = _resolve_enforcement_mode(config_path, "langchain", enforcement_mode)
+        self.evaluator = Evaluator(
+            config_path,
+            framework="langchain",
+            enforcement_mode=self.enforcement_mode,
+            harness="langchain",
+        )
 
     async def on_tool_start(self, serialized: Any, input_str: Any = None, **kwargs: object) -> None:
         tool_name = _tool_name(serialized)

--- a/python/langchain_adapter/middleware.py
+++ b/python/langchain_adapter/middleware.py
@@ -32,6 +32,7 @@ def _resolve_enforcement_mode(config_path: str | None, framework: str, explicit:
         or config.get("enforcementMode")
         or os.environ.get("APORT_ENFORCEMENT_MODE")
         or os.environ.get("APORT_ENFORCEMENT")
+        or os.environ.get("APORT_GUARDRAIL_ENFORCEMENT")
     )
 
 

--- a/python/langchain_adapter/middleware.py
+++ b/python/langchain_adapter/middleware.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +13,7 @@ except Exception:  # pragma: no cover - keeps the package usable without LangCha
 
 from aport_guardrails.core.config import find_config_path, load_config
 from aport_guardrails.core import Evaluator, GuardrailViolation, build_tool_context, tool_to_pack_id
+from aport_guardrails.core.display import format_policy_warning
 
 
 def _normalize_enforcement_mode(value: Any) -> str:
@@ -59,30 +59,13 @@ def _tool_input(input_str: Any, inputs: Any) -> str | dict[str, Any]:
     return str(value)
 
 
-def _sanitize_display(value: Any) -> str:
-    text = str(value or "").replace("\n", " ").replace("\r", " ").replace("\t", " ").replace("::", ": :")
-    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
-    replacements = (
-        (r"(?:apk|aprt)_[A-Za-z0-9_-]+", "[REDACTED_APORT_KEY]"),
-        (r"github_pat_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]"),
-        (r"gh[pousr]_[A-Za-z0-9_]+", "[REDACTED_GITHUB_TOKEN]"),
-        (r"xox[baprs]-[A-Za-z0-9-]+", "[REDACTED_SLACK_TOKEN]"),
-        (r"AKIA[0-9A-Z]{16}", "[REDACTED_AWS_KEY]"),
-        (r"(Authorization:?\s*Bearer|Bearer)\s+[A-Za-z0-9._~+/-]+=*", r"\1 [REDACTED]"),
-        (r"(password|passwd|pwd|token|secret|api[_-]?key)=\S+", r"\1=[REDACTED]"),
-        (r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", "[REDACTED_PRIVATE_KEY]"),
-    )
-    for pattern, replacement in replacements:
-        text = re.sub(pattern, replacement, text, flags=re.IGNORECASE | re.DOTALL)
-    return text[:240]
-
-
 class APortCallback(AsyncCallbackHandler):
     """Callback that verifies tool execution with APort before allowing. Auto-loads config from .aport/config.yaml or ~/.aport/langchain/."""
 
     raise_error = True
 
     def __init__(self, config_path: str | None = None, enforcement_mode: str | None = None) -> None:
+        self.config_path = config_path
         self.evaluator = Evaluator(config_path, framework="langchain")
         self.enforcement_mode = _resolve_enforcement_mode(config_path, "langchain", enforcement_mode)
 
@@ -102,8 +85,14 @@ class APortCallback(AsyncCallbackHandler):
             code = reasons[0].get("code", "oap.denied") if reasons else "oap.denied"
             if self.enforcement_mode == "warn":
                 print(
-                    f"[APort] warning: policy would have denied "
-                    f"{_sanitize_display(tool_name)}. Reason: {_sanitize_display(code)}."
+                    format_policy_warning(
+                        policy=pack_id,
+                        reason_code=code,
+                        reason_message=msg,
+                        tool_name=tool_name,
+                        framework="langchain",
+                        config_path=self.config_path,
+                    )
                 )
                 return
             raise GuardrailViolation(msg, code=code, reasons=reasons)

--- a/python/langchain_adapter/middleware.py
+++ b/python/langchain_adapter/middleware.py
@@ -66,8 +66,13 @@ class APortCallback(AsyncCallbackHandler):
 
     def __init__(self, config_path: str | None = None, enforcement_mode: str | None = None) -> None:
         self.config_path = config_path
-        self.evaluator = Evaluator(config_path, framework="langchain")
         self.enforcement_mode = _resolve_enforcement_mode(config_path, "langchain", enforcement_mode)
+        self.evaluator = Evaluator(
+            config_path,
+            framework="langchain",
+            enforcement_mode=self.enforcement_mode,
+            harness="langchain",
+        )
 
     async def on_tool_start(self, serialized: Any, input_str: Any = None, **kwargs: object) -> None:
         tool_name = _tool_name(serialized)

--- a/python/langchain_adapter/pyproject.toml
+++ b/python/langchain_adapter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aport-agent-guardrails-langchain"
-version = "1.0.31"
+version = "1.0.32"
 description = "APort Agent Guardrail for LangChain/LangGraph — AsyncCallbackHandler for AI agent tool calls"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "aport-agent-guardrails>=1.0.31,<2",
+    "aport-agent-guardrails>=1.0.32,<2",
 ]
 
 [project.optional-dependencies]

--- a/python/langchain_adapter/tests/test_callback.py
+++ b/python/langchain_adapter/tests/test_callback.py
@@ -66,6 +66,8 @@ class TestAPortCallback:
     async def test_warn_mode_does_not_raise(self):
         """Explicit warn mode lets LangChain continue while preserving the deny decision."""
         callback = APortCallback(config_path="/nonexistent", enforcement_mode="warn")
+        assert callback.evaluator._runtime_enforcement_mode == "warn"
+        assert callback.evaluator._runtime_harness == "langchain"
         callback.evaluator = AsyncMock()
         callback.evaluator.verify = AsyncMock(
             return_value={
@@ -104,6 +106,8 @@ class TestAPortCallback:
     async def test_compat_warn_mode_sanitizes_tool_name(self, capsys):
         """The compatibility import path must sanitize warn logs too."""
         callback = CompatAPortCallback(config_path="/nonexistent", enforcement_mode="warn")
+        assert callback.evaluator._runtime_enforcement_mode == "warn"
+        assert callback.evaluator._runtime_harness == "langchain"
         callback.evaluator = AsyncMock()
         callback.evaluator.verify = AsyncMock(
             return_value={

--- a/python/langchain_adapter/tests/test_callback.py
+++ b/python/langchain_adapter/tests/test_callback.py
@@ -98,6 +98,7 @@ class TestAPortCallback:
         captured = capsys.readouterr()
         assert "run_command : :error: :fake" in captured.out
         assert "\n::error::fake" not in captured.out
+        assert "Review:" in captured.out
 
     @pytest.mark.asyncio
     async def test_compat_warn_mode_sanitizes_tool_name(self, capsys):
@@ -116,3 +117,4 @@ class TestAPortCallback:
         captured = capsys.readouterr()
         assert "run_command : :error: :fake" in captured.out
         assert "\n::error::fake" not in captured.out
+        assert "Review:" in captured.out

--- a/python/langchain_adapter/tests/test_callback.py
+++ b/python/langchain_adapter/tests/test_callback.py
@@ -84,6 +84,27 @@ class TestAPortCallback:
         assert context["params"] == {"command": "rm -rf /"}
 
     @pytest.mark.asyncio
+    async def test_guardrail_enforcement_env_sets_warn_runtime_metadata(self, monkeypatch):
+        """APORT_GUARDRAIL_ENFORCEMENT should drive both LangChain behavior and hosted metadata."""
+        monkeypatch.delenv("APORT_ENFORCEMENT", raising=False)
+        monkeypatch.delenv("APORT_ENFORCEMENT_MODE", raising=False)
+        monkeypatch.setenv("APORT_GUARDRAIL_ENFORCEMENT", "warn")
+        callback = APortCallback(config_path="/nonexistent")
+        assert callback.evaluator._runtime_enforcement_mode == "warn"
+        assert callback.evaluator._runtime_harness == "langchain"
+        callback.evaluator = AsyncMock()
+        callback.evaluator.verify = AsyncMock(
+            return_value={
+                "allow": False,
+                "reasons": [{"code": "oap.command_not_allowed", "message": "Command not in allowlist"}],
+            }
+        )
+
+        await callback.on_tool_start({"name": "run_command"}, None, inputs={"command": "rm -rf /"})
+
+        callback.evaluator.verify.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_warn_mode_sanitizes_tool_name(self, capsys):
         """Warn logs must not let dynamic tool names forge terminal or CI records."""
         callback = APortCallback(config_path="/nonexistent", enforcement_mode="warn")

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -47,7 +47,10 @@ function buildRuntimeMetadata(options = {}) {
       "@aporthq/aport-agent-guardrails"
     ),
     harness: normalizeRuntimeString(
-      options.harness || process.env.APORT_HARNESS || process.env.APORT_FRAMEWORK,
+      options.harness ||
+        process.env.APORT_HOOK_FRAMEWORK ||
+        process.env.APORT_HARNESS ||
+        process.env.APORT_FRAMEWORK,
       "guardrails-shell"
     ),
   };

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -17,6 +17,42 @@
 const fs = require("fs");
 const path = require("path");
 
+function normalizeRuntimeString(value, fallback) {
+  const normalized = String(value || "")
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return (normalized || fallback).slice(0, 80);
+}
+
+function normalizeEnforcementMode(value) {
+  const raw = String(value || "enforce").trim().toLowerCase().replace(/_/g, "-");
+  return ["warn", "report-only", "audit-only", "observe", "observation"].includes(raw)
+    ? "warn"
+    : "enforce";
+}
+
+function buildRuntimeMetadata(options = {}) {
+  return {
+    enforcement_mode: normalizeEnforcementMode(
+      options.enforcementMode ||
+        options.enforcement_mode ||
+        process.env.APORT_ENFORCEMENT_MODE ||
+        process.env.APORT_ENFORCEMENT ||
+        process.env.APORT_GUARDRAIL_ENFORCEMENT
+    ),
+    enforced_by: normalizeRuntimeString(
+      options.enforcedBy || options.enforced_by,
+      "@aporthq/aport-agent-guardrails"
+    ),
+    harness: normalizeRuntimeString(
+      options.harness || process.env.APORT_HARNESS || process.env.APORT_FRAMEWORK,
+      "guardrails-shell"
+    ),
+  };
+}
+
 /**
  * Evaluate a policy using the APort API.
  *
@@ -83,6 +119,7 @@ async function evaluatePolicy(policyPack, passport, context, options = {}) {
   if (policyInBody) {
     bodyObj.policy = policyPack;
   }
+  bodyObj.runtime = buildRuntimeMetadata(options);
   const body = JSON.stringify(bodyObj);
 
   try {

--- a/tests/extensions/openclaw-aport.test.js
+++ b/tests/extensions/openclaw-aport.test.js
@@ -787,6 +787,11 @@ describe("plugin hook contract", () => {
       assert.strictEqual(seenBody.context.path, "README.md");
       assert.strictEqual(seenSignal, abortController.signal);
       assert.match(seenBody.context.idempotency_key, /^openclaw_[a-f0-9]+$/);
+      assert.deepStrictEqual(seenBody.runtime, {
+        enforcement_mode: "enforce",
+        enforced_by: "@aporthq/openclaw-aport",
+        harness: "openclaw",
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/tests/unit/test-claude-code-hook.sh
+++ b/tests/unit/test-claude-code-hook.sh
@@ -95,10 +95,44 @@ grep -q 'oap.input_too_large' "$OUT0C" || {
     cat "$OUT0C" >&2
     exit 1
 }
+grep -q 'systemMessage' "$OUT0C" || {
+    echo "FAIL: warn mode should include Claude Code systemMessage for user-visible warning" >&2
+    cat "$OUT0C" >&2
+    exit 1
+}
+grep -q 'Review:' "$OUT0C" || {
+    echo "FAIL: warn mode should include remediation/review reference" >&2
+    cat "$OUT0C" >&2
+    exit 1
+}
 cat > "$MODE_FILE" << 'EOF'
 APORT_GUARDRAIL_MODE=local
 EOF
 echo "  ✅ Oversized input: warn mode allows with warning"
+
+# shellcheck source=bin/lib/hook-runtime.sh
+source "$REPO_ROOT/bin/lib/hook-runtime.sh"
+JQ_BIN="$(command -v jq)"
+NO_JQ_PATH="$TEST_DIR/no-jq-path"
+mkdir -p "$NO_JQ_PATH"
+FALLBACK_JSON="$(
+    PATH="$NO_JQ_PATH"
+    hash -r
+    aport_hook_build_response_claude_code \
+        allow \
+        'APort warning: quoted "reason" with backslash \ content' \
+        $'Warn "quoted" text\nReview: https://aport.io/passports?details=ap_test'
+)"
+printf '%s' "$FALLBACK_JSON" | "$JQ_BIN" -e '
+  .hookSpecificOutput.permissionDecision == "allow"
+  and (.systemMessage | contains("Warn \"quoted\" text"))
+  and (.hookSpecificOutput.permissionDecisionReason | contains("quoted \"reason\""))
+' > /dev/null || {
+    echo "FAIL: Claude Code no-jq fallback should emit valid escaped JSON" >&2
+    printf '%s\n' "$FALLBACK_JSON" >&2
+    exit 1
+}
+echo "  ✅ no-jq Claude Code response fallback: valid escaped JSON"
 
 # 1. Allow: Read with allowed path (local evaluator)
 echo "  Test: Read tool -> allow (allowed path)..."

--- a/tests/unit/test-cursor-hook.sh
+++ b/tests/unit/test-cursor-hook.sh
@@ -103,6 +103,23 @@ echo "  ✅ oversized stdin: warn mode allows with warning"
 # shellcheck source=bin/lib/hook-runtime.sh
 source "$REPO_ROOT/bin/lib/hook-runtime.sh"
 JQ_BIN="$(command -v jq)"
+JQ_JSON="$(
+    aport_hook_build_response_cursor \
+        deny \
+        'APort denied: command not allowed' \
+        ''
+)"
+printf '%s' "$JQ_JSON" | "$JQ_BIN" -e '
+  .permission == "deny"
+  and .allowed == false
+  and .agentMessage == "APort denied: command not allowed"
+  and .agent_message == .agentMessage
+  and .user_message == .agentMessage
+' > /dev/null || {
+    echo "FAIL: Cursor response should preserve camel-case and snake-case message fields" >&2
+    printf '%s\n' "$JQ_JSON" >&2
+    exit 1
+}
 NO_JQ_PATH="$TEST_DIR/no-jq-path"
 mkdir -p "$NO_JQ_PATH"
 FALLBACK_JSON="$(
@@ -116,6 +133,7 @@ FALLBACK_JSON="$(
 printf '%s' "$FALLBACK_JSON" | "$JQ_BIN" -e '
   .permission == "allow"
   and .allowed == true
+  and .agentMessage == .user_message
   and (.user_message | contains("Warn \"quoted\" text"))
   and (.reason | contains("quoted \"reason\""))
 ' > /dev/null || {

--- a/tests/unit/test-cursor-hook.sh
+++ b/tests/unit/test-cursor-hook.sh
@@ -61,6 +61,11 @@ jq -e '.permission == "deny" and .allowed == false and (.reason | contains("oap.
     cat "$OUT0B" >&2
     exit 1
 }
+if jq -e 'has("hookSpecificOutput")' "$OUT0B" > /dev/null; then
+    echo "FAIL: Cursor hook must not emit Claude hookSpecificOutput schema" >&2
+    cat "$OUT0B" >&2
+    exit 1
+fi
 echo "  ✅ oversized stdin: fail-closed deny"
 
 cat > "$TEST_DIR/aport/guardrail-mode.env" << 'EOF'
@@ -83,6 +88,11 @@ jq -e '.permission == "allow" and .allowed == true and (.reason | contains("oap.
     cat "$OUT0C" >&2
     exit 1
 }
+if jq -e 'has("hookSpecificOutput")' "$OUT0C" > /dev/null; then
+    echo "FAIL: Cursor warn response must not emit Claude hookSpecificOutput schema" >&2
+    cat "$OUT0C" >&2
+    exit 1
+fi
 cat > "$TEST_DIR/aport/guardrail-mode.env" << 'EOF'
 APORT_GUARDRAIL_MODE=local
 EOF
@@ -92,6 +102,28 @@ echo "  ✅ oversized stdin: warn mode allows with warning"
 # Use octal escapes to keep this source file ASCII-stable.
 # shellcheck source=bin/lib/hook-runtime.sh
 source "$REPO_ROOT/bin/lib/hook-runtime.sh"
+JQ_BIN="$(command -v jq)"
+NO_JQ_PATH="$TEST_DIR/no-jq-path"
+mkdir -p "$NO_JQ_PATH"
+FALLBACK_JSON="$(
+    PATH="$NO_JQ_PATH"
+    hash -r
+    aport_hook_build_response_cursor \
+        allow \
+        'APort warning: quoted "reason" with backslash \ content' \
+        $'Warn "quoted" text\nReview: https://aport.io/passports?details=ap_test'
+)"
+printf '%s' "$FALLBACK_JSON" | "$JQ_BIN" -e '
+  .permission == "allow"
+  and .allowed == true
+  and (.user_message | contains("Warn \"quoted\" text"))
+  and (.reason | contains("quoted \"reason\""))
+' > /dev/null || {
+    echo "FAIL: Cursor no-jq fallback should emit valid escaped JSON" >&2
+    printf '%s\n' "$FALLBACK_JSON" >&2
+    exit 1
+}
+echo "  ✅ no-jq Cursor response fallback: valid escaped JSON"
 MULTIBYTE_RESULT="$(
     APORT_HOOK_STDIN_MAX_BYTES=4 APORT_HOOK_STDIN_CHUNK_BYTES=8 \
         aport_read_stdin_with_timeout < <(printf '\360\237\230\200\360\237\230\200')

--- a/tests/unit/test-evaluator-policy-in-body.cjs
+++ b/tests/unit/test-evaluator-policy-in-body.cjs
@@ -14,6 +14,8 @@ let capturedUrl;
 let capturedBody;
 
 const originalFetch = globalThis.fetch;
+const originalHookFramework = process.env.APORT_HOOK_FRAMEWORK;
+process.env.APORT_HOOK_FRAMEWORK = "cursor";
 globalThis.fetch = function (url, options) {
   capturedUrl = url;
   capturedBody = options && options.body ? JSON.parse(options.body) : null;
@@ -26,24 +28,31 @@ globalThis.fetch = function (url, options) {
 const { evaluatePolicy } = require("../../src/evaluator.js");
 
 (async () => {
-  await evaluatePolicy(policyPack, passport, context, {
-    apiUrl: "https://example.com",
-    policyInBody: true,
-  });
+  try {
+    await evaluatePolicy(policyPack, passport, context, {
+      apiUrl: "https://example.com",
+      policyInBody: true,
+    });
 
-  globalThis.fetch = originalFetch;
-
-  if (!capturedUrl.endsWith("/api/verify/policy/IN_BODY")) {
-    console.error("FAIL: expected URL to end with /api/verify/policy/IN_BODY, got", capturedUrl);
-    process.exit(1);
+    if (!capturedUrl.endsWith("/api/verify/policy/IN_BODY")) {
+      console.error("FAIL: expected URL to end with /api/verify/policy/IN_BODY, got", capturedUrl);
+      process.exit(1);
+    }
+    if (!capturedBody || !capturedBody.policy || capturedBody.policy.id !== policyPack.id) {
+      console.error("FAIL: expected body.policy to be the policy pack, got", capturedBody && capturedBody.policy);
+      process.exit(1);
+    }
+    if (capturedBody.runtime?.enforcement_mode !== "enforce" || capturedBody.runtime?.harness !== "cursor") {
+      console.error("FAIL: expected runtime enforcement metadata, got", capturedBody && capturedBody.runtime);
+      process.exit(1);
+    }
+    console.log("OK: policyInBody sends IN_BODY and body.policy");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalHookFramework === undefined) {
+      delete process.env.APORT_HOOK_FRAMEWORK;
+    } else {
+      process.env.APORT_HOOK_FRAMEWORK = originalHookFramework;
+    }
   }
-  if (!capturedBody || !capturedBody.policy || capturedBody.policy.id !== policyPack.id) {
-    console.error("FAIL: expected body.policy to be the policy pack, got", capturedBody && capturedBody.policy);
-    process.exit(1);
-  }
-  if (capturedBody.runtime?.enforcement_mode !== "enforce" || capturedBody.runtime?.harness !== "guardrails-shell") {
-    console.error("FAIL: expected runtime enforcement metadata, got", capturedBody && capturedBody.runtime);
-    process.exit(1);
-  }
-  console.log("OK: policyInBody sends IN_BODY and body.policy");
 })();

--- a/tests/unit/test-evaluator-policy-in-body.cjs
+++ b/tests/unit/test-evaluator-policy-in-body.cjs
@@ -41,5 +41,9 @@ const { evaluatePolicy } = require("../../src/evaluator.js");
     console.error("FAIL: expected body.policy to be the policy pack, got", capturedBody && capturedBody.policy);
     process.exit(1);
   }
+  if (capturedBody.runtime?.enforcement_mode !== "enforce" || capturedBody.runtime?.harness !== "guardrails-shell") {
+    console.error("FAIL: expected runtime enforcement metadata, got", capturedBody && capturedBody.runtime);
+    process.exit(1);
+  }
   console.log("OK: policyInBody sends IN_BODY and body.policy");
 })();


### PR DESCRIPTION
## Summary

Release APort Agent Guardrails 1.0.32 from staging to main.

This includes:
- Hosted runtime enforcement metadata so APort audit records distinguish signed policy decisions from framework runtime disposition (`enforce` vs `warn`).
- Shared sanitized warning/deny output across Claude Code, Cursor, LangChain, CrewAI, and OpenClaw paths.
- GitHub Repository Guard and hosted-first documentation updates.
- Synced policy submodule and package/version metadata across npm, PyPI, OpenClaw, and Claude plugin surfaces.

## Release behavior

Merging this PR to `main` should trigger the release-on-version workflow, which dispatches the Release workflow for `1.0.32`.

## Validation

Validated before opening:
- `npm run version`
- `npm run build`
- `bash scripts/pre-push-check.sh`
- TypeScript checks for CrewAI and LangChain packages
- Node LangChain tests
- Python CrewAI and LangChain targeted tests

## Notes

APort Repository Guard may flag protected runtime/release paths. That is expected for this release PR and should be handled through the trusted maintainer approval path, not by weakening repository protection.